### PR TITLE
Avoid using a separate dictionary for the interactive IPython namespace

### DIFF
--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -293,7 +293,7 @@ def start_ipython_with_autoimporter(argv=None, app=None, _user_ns=None):
         # be the same dict.  We should create a true ModuleType anyway even if
         # not using IPython.  We might need to resort to advising
         # init_create_namespaces etc. depending on IPython version.
-        if app.shell:
+        if getattr(app, 'shell', None) is not None:
             app.shell.user_ns.update(_user_ns)
         else:
             app.user_ns = _user_ns

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -293,7 +293,7 @@ def start_ipython_with_autoimporter(argv=None, app=None, _user_ns=None):
         # be the same dict.  We should create a true ModuleType anyway even if
         # not using IPython.  We might need to resort to advising
         # init_create_namespaces etc. depending on IPython version.
-        if app.shell.user_ns:
+        if app.shell:
             app.shell.user_ns.update(_user_ns)
         else:
             app.user_ns = _user_ns

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -293,7 +293,7 @@ def start_ipython_with_autoimporter(argv=None, app=None, _user_ns=None):
         # be the same dict.  We should create a true ModuleType anyway even if
         # not using IPython.  We might need to resort to advising
         # init_create_namespaces etc. depending on IPython version.
-        app.user_ns = _user_ns
+        app.shell.user_ns.update(_user_ns)
     return _initialize_and_start_app_with_autoimporter(app, argv)
 
 

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -293,7 +293,10 @@ def start_ipython_with_autoimporter(argv=None, app=None, _user_ns=None):
         # be the same dict.  We should create a true ModuleType anyway even if
         # not using IPython.  We might need to resort to advising
         # init_create_namespaces etc. depending on IPython version.
-        app.shell.user_ns.update(_user_ns)
+        if app.shell.user_ns:
+            app.shell.user_ns.update(_user_ns)
+        else:
+            app.user_ns = _user_ns
     return _initialize_and_start_app_with_autoimporter(app, argv)
 
 


### PR DESCRIPTION
That causes locals() and globals() to be separate dictionaries, which makes
the interactive namespace act like a class body instead of a module body,
i.e., "global" variables are not available inside of function bodies.

Fixes #16.

I still need to add a test. 