### PR TITLE
Don't print a stacktrace on KeyboardInterrupt in the py2/3 fallback

### DIFF
--- a/bin/tidy-imports
+++ b/bin/tidy-imports
@@ -143,7 +143,10 @@ def main():
                 raise
             logger.info("SyntaxError detected, falling back to %s", python)
             args = [python_full] + sys.argv + ['--no-py23-fallback']
-            subprocess.call(args)
+            try:
+                subprocess.call(args)
+            except KeyboardInterrupt:
+                pass
     else:
         process_actions(args, options.actions, modify)
 

--- a/bin/tidy-imports
+++ b/bin/tidy-imports
@@ -146,7 +146,7 @@ def main():
             try:
                 subprocess.call(args)
             except KeyboardInterrupt:
-                pass
+                sys.exit(1)
     else:
         process_actions(args, options.actions, modify)
 


### PR DESCRIPTION
https://github.com/pyflyby/pyflyby/issues/35