### PR TITLE
Add a --black flag to tidy-imports

### DIFF
--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -203,6 +203,11 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
         group.add_option('--width', type='int', default=79, metavar='N',
                          help=hfmt('''
                              Maximum line length (default: 79).'''))
+        group.add_option('--black', action='store_true', default=False,
+                         help=hfmt('''
+                             Use black to format imports. If this option is
+                             used, all other formatting options except for
+                             --width are ignored.'''))
         group.add_option('--hanging-indent', type='choice', default='never',
                          choices=['never','auto','always'],
                          metavar='never|auto|always',
@@ -263,6 +268,7 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
             from_spaces           =options.from_spaces,
             separate_from_imports =options.separate_from_imports,
             max_line_length       =options.width,
+            use_black             =options.black,
             align_future          =options.align_future,
             hanging_indent        =options.hanging_indent,
             )

--- a/lib/python/pyflyby/_format.py
+++ b/lib/python/pyflyby/_format.py
@@ -13,6 +13,7 @@ class FormatParams(object):
     wrap_paren = True
     indent = 4
     hanging_indent = 'never'
+    use_black = False
 
     def __new__(cls, *args, **kwargs):
         if not kwargs and len(args) == 1 and isinstance(args[0], cls):

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -454,7 +454,7 @@ class ImportStatement(object):
         return CompilerFlags(*[imp.flags for imp in self.imports])
 
     def pretty_print(self, params=FormatParams(),
-                     import_column=None, from_spaces=1):
+                     import_column=None, from_spaces=1, use_black=False):
         """
         Pretty-print into a single string.
 
@@ -462,6 +462,8 @@ class ImportStatement(object):
           `FormatParams`
         :param modulename_ljust:
           Number of characters to left-justify the 'from' name.
+        :param use_black:
+          Use black to format the import. If this is True, other flags are ignored.
         :rtype:
           ``str``
         """
@@ -490,7 +492,11 @@ class ImportStatement(object):
             else:
                 t = "%s" % (importname,)
             tokens.append(t)
-        return s0 + pyfill(s, tokens, params=params)
+        res = s0 + pyfill(s, tokens, params=params)
+        if use_black:
+            import black
+            return black.format_str(res, mode=black.FileMode())
+        return res
 
     @property
     def _data(self):

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -454,7 +454,7 @@ class ImportStatement(object):
         return CompilerFlags(*[imp.flags for imp in self.imports])
 
     def pretty_print(self, params=FormatParams(),
-                     import_column=None, from_spaces=1, use_black=False):
+                     import_column=None, from_spaces=1):
         """
         Pretty-print into a single string.
 
@@ -462,8 +462,6 @@ class ImportStatement(object):
           `FormatParams`
         :param modulename_ljust:
           Number of characters to left-justify the 'from' name.
-        :param use_black:
-          Use black to format the import. If this is True, other flags are ignored.
         :rtype:
           ``str``
         """
@@ -493,12 +491,9 @@ class ImportStatement(object):
                 t = "%s" % (importname,)
             tokens.append(t)
         res = s0 + pyfill(s, tokens, params=params)
-        if use_black:
+        if params.use_black:
             import black
-            if import_column is None:
-                mode = black.FileMode()
-            else:
-                mode = black.FileMode(line_length=import_column)
+            mode = black.FileMode(line_length=params.max_line_length)
             return black.format_str(res, mode=mode)
         return res
 

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -495,7 +495,11 @@ class ImportStatement(object):
         res = s0 + pyfill(s, tokens, params=params)
         if use_black:
             import black
-            return black.format_str(res, mode=black.FileMode())
+            if import_column is None:
+                mode = black.FileMode()
+            else:
+                mode = black.FileMode(line_length=import_column)
+            return black.format_str(res, mode=mode)
         return res
 
     @property


### PR DESCRIPTION
If `--black` is used, the imports are formatted with [black](https://black.readthedocs.io/en/stable/index.html). If it is used, all other formatting flags are ignored except for `--width`. 

Fixes #21.