### PR TITLE
Update README with D. E. Shaw Logo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -388,6 +388,16 @@ Emacs support
 
 Authorship
 ==========
+This plugin was contributed back to the community by the `D. E. Shaw group
+<https://www.deshaw.com/>`_.
+
+.. raw:: html
+
+   <p align="center">
+       <a href="https://www.deshaw.com">
+          <img src="https://www.deshaw.com/assets/logos/black_logo_417x125.png" alt" height="75" >
+       </a>
+   </p>
 
 Pyflyby is written by Karl Chen <quarl@8166.clguba.z.quarl.org>
 


### PR DESCRIPTION
D. E. Shaw logo used under these terms: https://www.deshaw.com/tmug