### PR TITLE
Make the --black flag ignore the pyflyby line length

### DIFF
--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -206,8 +206,7 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
         group.add_option('--black', action='store_true', default=False,
                          help=hfmt('''
                              Use black to format imports. If this option is
-                             used, all other formatting options except for
-                             --width are ignored.'''))
+                             used, all other formatting options are ignored.'''))
         group.add_option('--hanging-indent', type='choice', default='never',
                          choices=['never','auto','always'],
                          metavar='never|auto|always',

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -493,7 +493,7 @@ class ImportStatement(object):
         res = s0 + pyfill(s, tokens, params=params)
         if params.use_black:
             import black
-            mode = black.FileMode(line_length=params.max_line_length)
+            mode = black.FileMode()
             return black.format_str(res, mode=mode)
         return res
 


### PR DESCRIPTION
Fixes #72.