### PR TITLE
avoid excessive call of transformers on IPython 7.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
         pip install -U "pexpect>=3.3" pyflakes pytest epydoc rlipython requests jupyter flaky flake8;
     else
         pip install -U git+https://github.com/asmeurer/jupyter_console@display_completions;
-        pip install -U "pexpect>=3.3" pyflakes pytest rlipython requests jupyter flaky flake8;
+        pip install -U "pexpect>=3.3" pyflakes pytest rlipython requests jupyter flaky flake8 'notebook<6.1';
     fi
   - if [[ "${DOCS}" == "true" ]]; then
         pip install sphinx sphinx_rtd_theme sphinx-autodoc-typehints;

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -1839,6 +1839,10 @@ class AutoImporter(object):
                 logger.debug("reset_auto_importer_state(%r)", line)
                 self.reset_state_new_cell()
                 return line
+            # on IPython 7.17 (July 2020) or above, the check_complete 
+            # path of the code will not call  transformer that have this magic attribute 
+            # when trying to check whether the code is complete. 
+            reset_auto_importer_state.has_side_effect = True
             ip.input_transformers_cleanup.append(reset_auto_importer_state)
             return True
         elif hasattr(ip, "input_transformer_manager"):

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1878,13 +1878,21 @@ def test_autoimport_autocall_arg_1():
             [PYFLYBY] from base64 import b64decode
             Out[2]: 'KEYBOARD'
         """, autocall=True)
-    else:
+    elif IPython.version_info < (7, 17):
         # The autocall arrows are printed twice in newer versions of IPython
         # (https://github.com/ipython/ipython/issues/11714).
         ipython("""
             In [1]: import pyflyby; pyflyby.enable_auto_importer()
             In [2]: bytes.upper b64decode('a2V5Ym9hcmQ=')
             ------> bytes.upper(b64decode('a2V5Ym9hcmQ='))
+            ------> bytes.upper(b64decode('a2V5Ym9hcmQ='))
+            [PYFLYBY] from base64 import b64decode
+            Out[2]: b'KEYBOARD'
+        """, autocall=True)
+    else:
+        ipython("""
+            In [1]: import pyflyby; pyflyby.enable_auto_importer()
+            In [2]: bytes.upper b64decode('a2V5Ym9hcmQ=')
             ------> bytes.upper(b64decode('a2V5Ym9hcmQ='))
             [PYFLYBY] from base64 import b64decode
             Out[2]: b'KEYBOARD'
@@ -1901,7 +1909,7 @@ def test_autoimport_autocall_function_1():
             ------> b64decode('bW91c2U=')
             Out[2]: 'mouse'
         """, autocall=True)
-    else:
+    elif IPython.version_info < (7, 17):
         # The autocall arrows are printed twice in newer versions of IPython
         # (https://github.com/ipython/ipython/issues/11714).
         ipython("""
@@ -1909,6 +1917,14 @@ def test_autoimport_autocall_function_1():
             In [2]: b64decode 'bW91c2U='
             [PYFLYBY] from base64 import b64decode
             ------> b64decode('bW91c2U=')
+            ------> b64decode('bW91c2U=')
+            Out[2]: b'mouse'
+        """, autocall=True)
+    else:
+        ipython("""
+            In [1]: import pyflyby; pyflyby.enable_auto_importer()
+            In [2]: b64decode 'bW91c2U='
+            [PYFLYBY] from base64 import b64decode
             ------> b64decode('bW91c2U=')
             Out[2]: b'mouse'
         """, autocall=True)
@@ -2271,7 +2287,7 @@ def test_complete_symbol_autocall_arg_1():
             [PYFLYBY] from base64 import b64decode
             Out[2]: 'CHEWBACCA'
         """, autocall=True)
-    else:
+    elif IPython.version_info < (7,17):
         # The autocall arrows are printed twice in newer versions of IPython
         # (https://github.com/ipython/ipython/issues/11714).
         ipython("""
@@ -2282,6 +2298,16 @@ def test_complete_symbol_autocall_arg_1():
             [PYFLYBY] from base64 import b64decode
             Out[2]: b'CHEWBACCA'
         """, autocall=True)
+    else:
+        # IPython 7.17+ shoudl have fixed double autocall
+        ipython("""
+            In [1]: import pyflyby; pyflyby.enable_auto_importer()
+            In [2]: bytes.upper b64deco\tde('Q2hld2JhY2Nh')
+            ------> bytes.upper(b64decode('Q2hld2JhY2Nh'))
+            [PYFLYBY] from base64 import b64decode
+            Out[2]: b'CHEWBACCA'
+        """, autocall=True)
+
 
 @retry
 def test_complete_symbol_any_module_1(frontend, tmp):


### PR DESCRIPTION
IPython 7.17 does its best to not call transformer twice on the execution path; 
this ensure that 1) the test reflect this on IPython 7.17 (autocall for example is going to be printed only once), and  2) add an attribute to the transformer when those have side effect to avoid calling them in another path, when we try to detect whether the user input is complete or not.

-- 


Without this master on IPython 7.17 will likely fail, as the test are currently checking for an incorrect output which is now correct with IPython. I'm also expecting other test to fail so I may update this PR later with more fixes. 