### PR TITLE
Install jupyter_console latest (6.2).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         pip install -U "pexpect>=3.3" pyflakes pytest epydoc rlipython requests jupyter flaky flake8 wheel;
     else
-        pip install -U git+https://github.com/asmeurer/jupyter_console@display_completions;
-        pip install -U "pexpect>=3.3" pyflakes pytest rlipython requests jupyter flaky flake8 'notebook<6.1' 'prompt_toolkit<3.0.6' wheel;
+        pip install -U "pexpect>=3.3" pyflakes pytest rlipython requests jupyter flaky flake8 'notebook<6.1' 'prompt_toolkit<3.0.6' wheel 'jupyter_console>=6.2';
     fi
   - if [[ "${DOCS}" == "true" ]]; then
         pip install sphinx sphinx_rtd_theme sphinx-autodoc-typehints;


### PR DESCRIPTION
New version has been released and do not need to be installed from a
fork.