### PR TITLE
Separate lint in its own matrix entry.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       dist: xenial
       env:
         - TESTS="true"
+    - python: 3.8
+      dist: xenial
+      env:
+        - LINT="true"
     - python: 3.7
       env:
         - DOCS="true"
@@ -51,7 +55,7 @@ script:
   # which are all unused imports. We use flake8 so we can use noqa if
   # necessary.
   - |
-    if [[ "${TESTS}" == "true" ]]; then
+    if [[ "${LINT}" == "true" ]]; then
         flake8 --exclude known_imports,etc,__init__.py --select=F;
     fi
   # Test for invalid escape sequences (will be syntax errors in a future


### PR DESCRIPTION
This will make it a bit clearer if failure is lint, or actual tests,
and will also still run the test suite instead of aborting early.

This also lint only once instead of once-per-matrix-entry, which is
excessive.