### PR TITLE
Close return annotation wrong order.

### DIFF
--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -90,13 +90,26 @@ def _iter_child_nodes_in_order_internal_1(node):
             assert node._fields == ('name', 'args', 'body', 'decorator_list'), node._fields
             yield node.decorator_list, node.args, node.body
         elif sys.version_info >= (3, 8):
-            assert node._fields == ('name', 'args', 'body', 'decorator_list',
-                                    'returns', 'type_comment'), node._fields
-            yield node.type_comment, node.returns, node.decorator_list, node.args, node.body
+            assert node._fields == (
+                "name",
+                "args",
+                "body",
+                "decorator_list",
+                "returns",
+                "type_comment",
+            ), node._fields
+            res = (
+                node.type_comment,
+                node.decorator_list,
+                node.args,
+                node.returns,
+                node.body,
+            )
+            yield res
         else:
             assert node._fields == ('name', 'args', 'body', 'decorator_list',
                                     'returns'), node._fields
-            yield node.returns, node.decorator_list, node.args, node.body
+            yield node.decorator_list, node.args, node.returns, node.body
         # node.name is a string, not an AST node
     elif isinstance(node, ast.arguments):
         if six.PY2:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1306,3 +1306,18 @@ def test_parsable_missing_flags_auto_flags_1():
 def test_parsable_Call_Ast_args_kwargs(input):
     block = PythonBlock(input, auto_flags=True)
     assert block.annotated_ast_node
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="invalid early python syntax")
+@pytest.mark.parametrize(
+    "input",
+    [
+        """
+def func(x: List[int], y: List[int]) -> List[int]:
+    return x + y
+"""
+    ],
+)
+def test_parsable_annotation_order(input):
+    block = PythonBlock(input, auto_flags=True)
+    assert block.annotated_ast_node


### PR DESCRIPTION
Closes #93; returned typed annotation is is wrong order with respect to
other ast nodes.