### PR TITLE
Fix parsing of multiline continuation strings.

### DIFF
--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -348,10 +348,12 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
     # joined strings and children do not carry a column offset on pre-3.8
     # this prevent reformatting.
     # set the column offset to the parent value before 3.8
-    if (3, 0) <= sys.version_info < (3, 8):
+    if (3, 6) < sys.version_info < (3, 8):
         if (
-            isinstance(ast_node, ast.JoinedStr)
-            or isinstance(parent_ast_node, (ast.JoinedStr, ast.FormattedValue))
+            isinstance(ast_node, getattr(ast, "JoinedStr", None))
+            or isinstance(
+                parent_ast_node, (getattr(ast, "JoinedStr", None), ast.FormattedValue)
+            )
         ) and ast_node.col_offset == -1:
             ast_node.col_offset = parent_ast_node.col_offset
 

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -345,6 +345,16 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
     :raise ValueError:
       Could not find the starting line number.
     """
+    # joined strings and children do not carry a column offset on pre-3.8
+    # this prevent reformatting.
+    # set the column offset to the parent value before 3.8
+    if sys.version_info < (3, 8):
+        if (
+            isinstance(ast_node, ast.JoinedStr)
+            or isinstance(parent_ast_node, (ast.JoinedStr, ast.FormattedValue))
+        ) and ast_node.col_offset == -1:
+            ast_node.col_offset = parent_ast_node.col_offset
+
     # First, traverse child nodes.  If the first child node (recursively) is a
     # multiline string, then we need to transfer its information to this node.
     # Walk all nodes/fields of the AST.  We implement this as a custom

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -348,7 +348,7 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
     # joined strings and children do not carry a column offset on pre-3.8
     # this prevent reformatting.
     # set the column offset to the parent value before 3.8
-    if sys.version_info < (3, 8):
+    if (3, 0) <= sys.version_info < (3, 8):
         if (
             isinstance(ast_node, ast.JoinedStr)
             or isinstance(parent_ast_node, (ast.JoinedStr, ast.FormattedValue))

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1376,3 +1376,19 @@ def func(x: List[int], y: List[int]) -> List[int]:
 def test_parsable_annotation_order(input):
     block = PythonBlock(input, auto_flags=True)
     assert block.annotated_ast_node
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="invalid early python syntax")
+@pytest.mark.parametrize(
+    "input",
+    [
+        """
+x = 123
+fail_here = f"{x.stem} is no-op. \\
+(Do we need to delete this still?)"
+"""
+    ],
+)
+def test_join_formatted_string_columns(input):
+    block = PythonBlock(input, auto_flags=True)
+    assert block.annotated_ast_node


### PR DESCRIPTION
In Python 3.7 and before; this is not correctly handled as as
JoinedStr and children do not have column offset.

Note that in the test double backslash is necessary in order for the
test to see a single `\`

Closes #104