### PR TITLE
Remove deprecated collections imports from Python 3

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, print_function,
                         with_statement)
 
 import ast
-from collections import Sequence
 import contextlib
 import copy
 import six
@@ -14,6 +13,13 @@ from   six                      import PY2, PY3, exec_, reraise
 from   six.moves                import builtins
 import sys
 import types
+
+if PY3:
+    from collections.abc import Sequence
+else:
+    # This is deprecated in Python 3
+    from collections import Sequence
+
 
 from   pyflyby._file            import FileText, Filename
 from   pyflyby._flags           import CompilerFlags

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, print_function,
                         with_statement)
 
-from   collections              import Callable
 from   contextlib               import contextmanager
 import errno
 from   functools                import wraps
@@ -18,6 +17,11 @@ from   types                    import CodeType, FrameType, TracebackType
 
 import six
 from   six.moves                import builtins
+
+if six.PY3:
+    from   collections.abc          import Callable
+else:
+    from   collections              import Callable
 
 from   pyflyby._file            import Filename
 


### PR DESCRIPTION
The tests are run with deprecation warnings turned into errors, so without
this, the tests fail.