### PR TITLE
Fix bytes literal annotation parsing.

### DIFF
--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -498,6 +498,9 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
             for _m in re.finditer("[bBrRuU]*[\"\']", start_line)])
     target_str = ast_node.s
 
+    if isinstance(target_str, bytes) and sys.version_info[:2] == (3, 7):
+        target_str = target_str.decode()
+
     # Loop over possible end_linenos.  The first one we've identified is the
     # by far most likely one, but in theory it could be anywhere later in the
     # file.  This could be because of a dastardly concatenated string like
@@ -556,6 +559,8 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
             # string literal.
             subtext = text[startpos:endpos]
             candidate_str = _test_parse_string_literal(subtext, flags)
+            if isinstance(candidate_str, bytes) and sys.version_info[:2] == (3, 7):
+                candidate_str = candidate_str.decode()
             if candidate_str is None:
                 continue
             elif target_str == candidate_str:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1392,3 +1392,25 @@ fail_here = f"{x.stem} is no-op. \\
 def test_join_formatted_string_columns(input):
     block = PythonBlock(input, auto_flags=True)
     assert block.annotated_ast_node
+
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        '''b"""
+two
+""" b"""
+four
+five
+six
+"""
+''',
+        '''
+print(b"""
+""", sep="")
+''',
+    ],
+)
+def test_bytes_concat(input):
+    block = PythonBlock(input, auto_flags=True)
+    assert block.annotated_ast_node


### PR DESCRIPTION
We decode bytes into stings when in Python 3.7, it's ok as we are only annotating nodes and mix of bytes and str are invalid syntax so we will never encounter them anyway.