### PR TITLE
Attempt to fix parsing of concatenated fstrings in python 3.7

### DIFF
--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1421,6 +1421,7 @@ def _normalize_python_2_3(template):
         print("_normalize_python_2_3() %r => %r" % (template0, template))
     return template
 
+
 @retry
 def test_ipython_1(frontend):
     # Test that we can run ipython and get results back.

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1382,6 +1382,42 @@ def test_parsable_annotation_order(input):
 @pytest.mark.parametrize(
     "input",
     [
+        '''x='abc'
+f"""\
+This is a
+multi-line
+f-string
+with input {x}.\
+"""
+''',
+        '''x=123
+f"""\
+{x}
+is the value x
+"""
+''',
+        '''x=456
+f"""{x}
+is the value x
+"""
+''',
+        '''x=123
+f"""\
+In the middle
+{x}
+is the value.
+"""
+''',
+    ],
+)
+def test_parse_f_string_ast_ann(input):
+    block = PythonBlock(input, auto_flags=True)
+    assert block.annotated_ast_node
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="invalid early python syntax")
+@pytest.mark.parametrize(
+    "input",
+    [
         """
 x = 123
 fail_here = f"{x.stem} is no-op. \\


### PR DESCRIPTION
Fixes #107

This only apply to Python 3.7 as ast does not have all the right values;
and this will likely mean that the value of node's startpos and endpos
are incorrect, but still sufficiently close to allow most of the
refactoring tool to do their work.