### PR TITLE
add travis-ci on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ matrix:
     - python: 2.7
       env:
         - TESTS="true"
+    - python: 3.6
+      dist: xenial
+      env:
+        - TESTS="true"
     - python: 3.7
       dist: xenial
       env:


### PR DESCRIPTION
If we don't do that, we should be explicit Python 3.6 is not supported.