### PR TITLE
Add tests that async-def functions are understood.

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -426,6 +426,11 @@ class _MissingImportFinder(object):
                 self.visit(item)
         elif isinstance(node, ast.AST):
             method = 'visit_' + node.__class__.__name__
+            if not hasattr(self, method):
+                logger.debug(
+                    "_MissingImportFinder has no method %r, using generic_visit", method
+                )
+
             visitor = getattr(self, method, self.generic_visit)
             return visitor(node)
         else:
@@ -527,6 +532,9 @@ class _MissingImportFinder(object):
         # The class's name is only visible to others (not to the body to the
         # class).
         self._visit_Store(node.name)
+
+    def visit_AsyncFunctionDef(self, node):
+        return self.visit_FunctionDef(node)
 
     def visit_FunctionDef(self, node):
         # Visit a function definition.

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -1133,6 +1133,21 @@ def test_find_missing_imports_yield_from_1():
     expected = ['g']
     assert expected == result
 
+
+@pytest.mark.skipif(PY2, reason="Python 3-only syntax.")
+def test_find_missing_imports_not_async_def():
+    code = dedent(
+        """
+    async def f():
+        pass
+    f()
+    """
+    )
+    result = find_missing_imports(code, [{}])
+    expected = []
+    assert expected == result
+
+
 def test_find_missing_imports_nested_with_1():
     # Handled differently in the ast in Python 2 and 3
     code = dedent("""


### PR DESCRIPTION
Async def functions are currently not understood as name definition as
the ast walking class did not had a case of AsyncDefFunction.