### PR TITLE
Fix simple case of list comprehension name def

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -854,8 +854,10 @@ class _MissingImportFinder(object):
             # On the other hand, we intentionally alias the other scopes
             # rather than cloning them, because the point is to allow them to
             # be modified until we do the check at the end.
-            data = (fullname, self.scopestack.clone_top(), self._lineno)
-            self._deferred_load_checks.append(data)
+
+            if symbol_needs_import(fullname, self.scopestack):
+                data = (fullname, self.scopestack.clone_top(), self._lineno)
+                self._deferred_load_checks.append(data)
         else:
             # We're not in a FunctionDef.  Deferring would give us the same
             # result; we do the check now to avoid the overhead of cloning the

--- a/tests/test_imports2s.py
+++ b/tests/test_imports2s.py
@@ -964,6 +964,25 @@ def test_fix_unused_imports_dunder_file_1(capsys):
     assert "undefined name '__file__'" not in out
     assert not err
 
+
+def test_x_shadow_comprehension(capsys):
+    input = PythonBlock(
+        dedent(
+            """
+    def f():
+        x = 1
+        y = [x for _ in range(5)]
+        del x
+    """
+        )
+    )
+    db = ImportDB("")
+    output = fix_unused_and_missing_imports(input, db=db)
+    out, err = capsys.readouterr()
+    assert output == input
+    assert "undefined name 'x'" not in out
+    assert not err
+
 def test_fix_unused_imports_submodule_1():
     input = PythonBlock(dedent('''
         import m2.y

--- a/tests/test_imports2s.py
+++ b/tests/test_imports2s.py
@@ -604,6 +604,16 @@ def test_fix_missing_imports_nonlocal_post_store_1():
 
 
 def test_fix_missing_imports_nonlocal_post_del_1():
+    """
+    Calling F2 after the deletion of x2 in the enclosing scope make no sens, it
+    would trigger a:
+
+    NameError: free variable 'x2' referenced before assignment in enclosing scope
+
+    Regardless as to whether x2 is defines at module scope or not.
+
+    Therefore we do not expect x2 to be imported
+    """
     input = PythonBlock(dedent('''
         def F1():
             x1 = x2 = None
@@ -614,7 +624,7 @@ def test_fix_missing_imports_nonlocal_post_del_1():
     db = ImportDB("from m2 import x1, x2, x3, x4")
     output = fix_unused_and_missing_imports(input, db=db)
     expected = PythonBlock(dedent('''
-        from m2 import x2, x3
+        from m2 import x3
 
     ''').lstrip() + str(input))
     assert output == expected


### PR DESCRIPTION
This change the resolving of names from deferring to actually try to be
greedy, and fallback to lazy if cant' resolve.

This fixes case like

    $ tidy-imports <<EOF
    from __future__ import absolute_import, division, print_function
    def f():
        x = 1
        y = [x for _ in range(5)]
        del x
    EOF
    [PYFLYBY] /dev/stdin:4: undefined name 'x' and no known import for it
    from __future__ import absolute_import, division, print_function
    def f():
        x = 1
        y = [x for _ in range(5)]
        del x

but will likely fail in other case like

    def f():
        def g():
            y = [x for _ in range(5)]
            return y
        x = 1
        g()
        del x

This will also change the behavior of:

    def F1():
         x1 = x2 = None
         def F2():
             x1, x2, x3, y1
         del x2

Where x2 is now going to be resolved instead of not. This is ambiguous
as we don't know when F2 will be called and thus wether x2 needs to be
imported or not.

Partial toward #95 