### PR TITLE
Allow reformat message to carry list of imports.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ script:
     fi
   - |
     if [[ "${TESTS}" == "true" ]]; then
-        pytest --doctest-modules lib tests;
+        pytest -x --doctest-modules lib tests;
     fi
   # Smoke test tidy-imports on the codebase. This only fails if there is an
   # exception from a bug, but we could also make it fail if there are imports

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -23,7 +23,7 @@ from   pyflyby._autoimp         import (LoadSymbolError, ScopeStack, auto_eval,
                                         clear_failed_imports_cache,
                                         load_symbol)
 from   pyflyby._comms           import (initialize_comms, remove_comms,
-                                        send_comm_message)
+                                        send_comm_message, MISSING_IMPORTS)
 from   pyflyby._file            import Filename, atomic_write_file, read_file
 from   pyflyby._idents          import is_identifier
 from   pyflyby._importdb        import ImportDB
@@ -2452,7 +2452,7 @@ class AutoImporter(object):
             namespaces = get_global_namespaces(self._ip)
 
         def post_import_hook(imp):
-            send_comm_message("pyflyby.missing_imports", {"missing_imports": str(imp)})
+            send_comm_message(MISSING_IMPORTS, {"missing_imports": str(imp)})
 
         return self._safe_call(
             auto_import, arg, namespaces,


### PR DESCRIPTION
This can be used by the jupyterlab-pyflyby extension to reformat and
insert imports in the first cell in a single requests.

The alternate is to have a single "insert imports" message, but that
make the typescript extension prone to race condition and make the login
much more complicated.