### PR TITLE
Workaround #123 on old python.

### DIFF
--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -447,6 +447,8 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
             startpos = FilePos(startpos.lineno, startpos.colno - lk)
             assert str(text[startpos:(startpos+(0,4))]) == "with"
         ast_node.startpos = startpos
+        if sys.version_info <= (3, 8):
+            ast_node.startpos = max(startpos, minpos)
         return False
 
     assert ast_node.col_offset == -1

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -663,6 +663,8 @@ class AnsiFilterDecoder(object):
         arg = re.sub(br"\x1b\[([0-9]+)D\x1b\[\1C", b"", arg) # left8,right8 no-op (srsly?)
         arg = arg.replace(b'\x1b[?1034h', b'')        # meta key
         arg = arg.replace(b'\x1b>', b'')              # keypad numeric mode (???)
+        arg = arg.replace(b'?[33m', b'')              # (???)
+        arg = arg.replace(b'?[0m', b'')              # (???)
 
         
         # cursor movement on PTK 3.0.6+ compute the number of back and forth and

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1427,7 +1427,22 @@ def test_parse_f_string_ast_ann(input):
 x = 123
 fail_here = f"{x.stem} is no-op. \\
 (Do we need to delete this still?)"
-"""
+""",'''
+BLAH = "blah"
+
+def f(t):
+    pass
+
+f(f"""
+{BLAH}
+""")
+''',
+'''
+def foo():
+    return f"""
+        {name}
+    """
+'''
     ],
 )
 def test_join_formatted_string_columns(input):


### PR DESCRIPTION
Python versions older than 3.8 do no carry enough ast informations to
properly annotate ast position. Therefore if we find an annotate ast
position of children that is too small we clip it to the current minpos.