### PR TITLE
Allow __all__ to export names in a module

### DIFF
--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -1564,6 +1564,17 @@ def test_setattr_is_not_unused():
     assert unused == []
 
 
+def test_all_exports_1():
+    code = dedent("""
+        from os import path, walk, read
+        __all__ = ['path', 'rmdir', 'walk']
+    """)
+    missing, unused = scan_for_import_issues(code)
+    # path and walk should not be unused
+    assert missing == [(3, DottedIdentifier('rmdir'))]
+    assert unused == [(2, Import('from os import read'))]
+
+
 def test_load_symbol_1():
     assert load_symbol("os.path.join", {"os": os}) is os.path.join
 


### PR DESCRIPTION
Currently only a single __all__ = <list of str> is supported. Additional
manipulation of __all__, such as +=, could be added if needed.

Fixes #133.