### PR TITLE
Allow relative paths in which()

### DIFF
--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -212,8 +212,6 @@ def which(program):
     :return:
       Program on $PATH, or ``None`` if not found.
     """
-    if "/" in program:
-        raise ValueError("which(): input should be a basename")
     # See if it exists in the current directory.
     candidate = Filename(program)
     if candidate.isreadable:


### PR DESCRIPTION
This lets 'py path/to/file.py' work. The exception doesn't seem to serve any
purpose, since the line after it will return the path if it exists.

Fixes #126.