### PR TITLE
Do not access f_locals, which reset changes.

### DIFF
--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -897,6 +897,7 @@ def _get_pdb_if_is_in_pdb():
     # Found a pdb frame.
     pdb_frame = pdb_frames[0]
     import pdb
+
     pdb_instance = pdb_frame.f_locals.get("self", None)
     if (type(pdb_instance).__name__ == "Pdb" or
         isinstance(pdb_instance, pdb.Pdb)):
@@ -937,7 +938,7 @@ def get_global_namespaces(ip):
     # logger.debug("get_global_namespaces(): pdb_instance=%r", pdb_instance)
     if pdb_instance:
         frame = pdb_instance.curframe
-        return [frame.f_globals, frame.f_locals]
+        return [frame.f_globals, pdb_instance.curframe_locals]
     elif ip:
         return [ns for nsname, ns in _ipython_namespaces(ip)][::-1]
     else:
@@ -1114,7 +1115,7 @@ def _list_members_for_completion(obj, ip):
 
 def _auto_import_in_pdb_frame(pdb_instance, arg):
     frame = pdb_instance.curframe
-    namespaces = [ frame.f_globals, frame.f_locals ]
+    namespaces = [ frame.f_globals, pdb_instance.curframe_locals ]
     filename = frame.f_code.co_filename
     if not filename or filename.startswith("<"):
         filename = "."

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -2801,6 +2801,46 @@ def test_run_i_auto_import_1(tmp):
         Out[3]: b'Gauss'
     """.format(tmp=tmp))
 
+def test_run_d_donterase(tmp):
+    """
+    accessing f_locals may reset namespace,
+    here we check that myvar changes after assignment in the debugger.
+    """
+    ipython(
+        """
+        In [1]: import pyflyby; pyflyby.enable_auto_importer()
+        In [2]: def simple_f():
+           ...:     myvar = 1
+           ...:     print(myvar)
+           ...:     1/0
+           ...:     print(myvar)
+           ...: simple_f()
+        1
+        ---------------------------------------------------------------------------
+        ZeroDivisionError                         Traceback (most recent call last)
+        <ipython-input> in <module>
+              4     1/0
+              5     print(myvar)
+        <ipython-input> in simple_f()
+              2 myvar = 1
+              3 print(myvar)
+              5 print(myvar)
+        ZeroDivisionError: division by zero
+        In [3]: %debug
+        > <ipython-input>(4)simple_f()
+              2     myvar = 1
+              3     print(myvar)
+              5     print(myvar)
+              6 simple_f()
+        ipdb> myvar
+        1
+        ipdb> myvar = 2
+        ipdb> myvar
+        2
+        ipdb> c
+"""
+    )
+
 
 @retry
 def test_run_i_already_imported_1(tmp):


### PR DESCRIPTION
Given a file

    $ cat simple.py
    import ipdb

    def simple_f():
        myvar = 1
        print(myvar)
        ipdb.set_trace()
        print(myvar)

    if __name__ == '__main__':
        simple_f()

And running IPython with the pyflyby extension, we observe that changes
of values are not propagates to current frame:

    In [1]: %run -d simple.py
    NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
    > simple.py(1)<module>()
    ----> 1 import ipdb
          2
          3 def simple_f():
          4     myvar = 1
          5     print(myvar)

    ipdb> c
    1
    > simple.py(7)simple_f()
          5     print(myvar)
          6     ipdb.set_trace()
    ----> 7     print(myvar)
          8
          9

    ipdb> myvar
    1
    ipdb> myvar = 2
    ipdb> myvar
    1
    ipdb> c
    1

this is due to the fact that accessing `curframe.f_locals` has side
effects and reset the value to the original one. CPython seem to use
`self.curframe_locals` to this effect to avoid side effects.

I'm not too sure of the effect this will have on autoreload. It is
also not the only things that access f_locals, in Particular IPython it
self does it in a couple of place to for example hide frames, and thus
currently ipdb's `where` also reset the default values. Thereforre
IPython will need to be modified as well.