### PR TITLE
Append instead of prepend python_matches.

### DIFF
--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -2174,7 +2174,7 @@ class AutoImporter(object):
                 if completer.python_matches not in completer.matchers:
                     @self._advise(type(completer).matchers)
                     def matchers_with_python_matches(completer):
-                        return [completer.python_matches] + __original__.fget(completer)
+                        return __original__.fget(completer)+[completer.python_matches]
 
             @self._advise(completer.global_matches)
             def global_matches_with_autoimport(fullname):


### PR DESCRIPTION
The ordering is important in particular in some case,
the values returned will be the first matching completions,
If Python matches is always prepended, then there is no change for
better matchers (like dict keys), to be triggered.