### PR TITLE
Second fix for #147 (ClassDef=>FunctionDef=>setattr).

### DIFF
--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -484,6 +484,35 @@ def test_find_missing_import_xfail_after_pr_152():
     assert result == expected
 
 
+def test_method_reference_current_class():
+    """
+    A method can reference the current class
+
+    But only if this is a toplevel class, nesting won't work in Python.
+    """
+    code = dedent(
+        """
+       class Decimal:
+           def foo(self):
+               Decimal.x = 1
+               Float.y=1
+
+           class Real:
+
+               def foo():
+                   Real.r = 1
+   """
+    )
+    missing, unused = scan_for_import_issues(code, [{}])
+    # result = _dilist2strlist(result)
+    assert missing == [
+        (5, DottedIdentifier("Float.y")),
+        (10, DottedIdentifier("Real.r")),
+    ]
+    assert unused == []
+
+
+
 def test_find_missing_imports_class_name_1():
     code = dedent(
         """


### PR DESCRIPTION
This is not my prefered fix, but it should not be too complicated.

Basically the current class can be accessed from within one of it's
method only when it's a toplevel class.

Though it is not available in the class body.

With the current structure as a Depth first search evaluator it's a bit
hard to get the same behavior as python, in particular as the new scope
that is created when evaluating a class body remove the class def,

I'm guessing it would with a BFS, where you evaluate all the function
definition in the class body before binding the class and recursing but
this is too much of a refactor.

So what we do for now is have a hidden namespace when we visit a class
def. If this namespace is non-empty (ie Top level class), we store the
current class name in it. And when we visit the body of a Function def
(likely a method), we pop it at the front of the stack. This is
_technically_ incorrect as it is now the lowest priority item, but at
least it exists, which shouldn't change much.

One of the strange behavior of this bug is that it only appear with tidy
import, as we are trying to find unused imports. Which I've tried to
reflect in new tests, and without breaking others.

Nonetheless these are really edge case behavior of Python and one should
likely try when possible to not rely on these.