### PR TITLE
Fix type comment on function (#171)

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -640,16 +640,34 @@ class _MissingImportFinder(object):
                 self.visit(node.body)
             self._in_FunctionDef = old_in_FunctionDef
 
-    def _visit_typecomment(self, typecomment):
+    def _visit_typecomment(self, typecomment:str):
+        """
+        Warning, when a type comment the node is a string, not an ast node.
+        We also get two types of type comments:
+
+
+        The signature one just after a function definition
+
+            def foo(a):
+                # type: int -> None
+                pass
+
+        And the variable annotation ones:
+
+            def foo(a #type: int
+                ):
+                pass
+
+        ast parse  "func_type" mode only support the first one.
+
+        """
         if typecomment is None:
             return
+        if '->' in typecomment:
+            node = ast.parse(typecomment, mode='func_type')
+        else:
+            node = ast.parse(typecomment)
 
-        # TODO: This seem incorrect as it was before, and as it is now,
-        # at least I don't think that ast.parse used to, or can parse the type comments
-        # in vaccum like this, they have to be part of a function definition.
-        # think this might need to be mode="func_type" (https://docs.python.org/3/library/ast.html#ast.parse)
-        return
-        node = ast.parse(typecomment, type_comments=True)
         self.visit(node)
 
     def visit_arguments(self, node):

--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -643,7 +643,13 @@ class _MissingImportFinder(object):
     def _visit_typecomment(self, typecomment):
         if typecomment is None:
             return
-        node = ast.parse(typecomment)
+
+        # TODO: This seem incorrect as it was before, and as it is now,
+        # at least I don't think that ast.parse used to, or can parse the type comments
+        # in vaccum like this, they have to be part of a function definition.
+        # think this might need to be mode="func_type" (https://docs.python.org/3/library/ast.html#ast.parse)
+        return
+        node = ast.parse(typecomment, type_comments=True)
         self.visit(node)
 
     def visit_arguments(self, node):

--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -640,7 +640,7 @@ class _MissingImportFinder(object):
                 self.visit(node.body)
             self._in_FunctionDef = old_in_FunctionDef
 
-    def _visit_typecomment(self, typecomment:str):
+    def _visit_typecomment(self, typecomment):
         """
         Warning, when a type comment the node is a string, not an ast node.
         We also get two types of type comments:

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -57,6 +57,9 @@ def _flatten_ast_nodes(arg):
         pass
     elif isinstance(arg, ast.AST):
         yield arg
+    elif isinstance(arg, str):
+        #FunctionDef type_comments
+        yield arg
     elif isinstance(arg, (tuple, list, types.GeneratorType)):
         for x in arg:
             for y in _flatten_ast_nodes(x):
@@ -81,6 +84,11 @@ def _iter_child_nodes_in_order(node):
 
 
 def _iter_child_nodes_in_order_internal_1(node):
+    if isinstance(node, str):
+        # this happen for type comments which are not ast nodes but str
+        # they do not have children. We yield nothing.
+        yield []
+        return
     if not isinstance(node, ast.AST):
         raise TypeError
     if isinstance(node, ast.Dict):
@@ -632,6 +640,7 @@ def _annotate_ast_context(ast_node):
 
     For non-list fields, the index part is ``None``.
     """
+    assert isinstance(ast_node, ast.AST)
     for field_name, field_value in ast.iter_fields(ast_node):
         if isinstance(field_value, ast.AST):
             child_node = field_value

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -1282,6 +1282,52 @@ def test_scan_for_import_issues_type_comment_1():
     assert unused == []
     assert missing == []
 
+
+# Only Python 3.8 includes type comments in the ast, so we only support this
+# there (see issue #31, 171, 174).
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="Python 3.8+-only support.")
+def test_scan_for_import_issues_type_comment_2():
+    code = dedent("""
+    from typing import Sequence
+    def foo(strings):
+        # type: (Sequence[str]) -> None
+        pass
+    """)
+    missing, unused = scan_for_import_issues(code)
+    assert unused == []
+    assert missing == []
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="Python 3.8+-only support.")
+def test_scan_for_import_issues_type_comment_3():
+    code = dedent("""
+    def foo(strings):
+        # type: (Sequence[str]) -> None
+        pass
+    """)
+    missing, unused = scan_for_import_issues(code)
+    assert unused == []
+    assert missing == [(1, DottedIdentifier('Sequence'))]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="Python 3.8+-only support.")
+def test_scan_for_import_issues_type_comment_4():
+    code = dedent("""
+    from typing import Sequence, Tuple
+    def foo(strings):
+        # type: (Sequence[str]) -> None
+        pass
+    """)
+    missing, unused = scan_for_import_issues(code)
+    assert unused == [(2, Import('from typing import Tuple'))]
+    assert missing == []
+
 # Python 3.8 uses the correct line number for multiline strings (the first
 # line), making _annotate_ast_startpos irrelevant. Otherwise, the logic for
 # getting this right is too hard. See issue #12.


### PR DESCRIPTION
#171 was due to the fact that type comments in ast are string and not ast nodes, 
this had wide repercussions in many places but I try to do the smallest fix as possible.
Previous work on type comments only focused on variable annotation, so I extended the test suite with a couple of function types comments as well.

I'm expecting CI to fail as it fails on master, so I'll likely need to fix CI first