### PR TITLE
MAINT: CI failing, pin pytest to <7, coverage to <6.3 IPython to <8. 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       if: ${{ matrix.python-version != '2.7'}}
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade "pexpect>=3.3" pyflakes 'pytest<7' rlipython ipykernel==5.4.3 requests jupyter flaky flake8 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3'
+        python -m pip install --upgrade "pexpect>=3.3" pyflakes 'pytest<7' rlipython ipykernel==5.4.3 requests jupyter flaky flake8 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3' 'ipython<8'
         pip install -e .
     - name: test release build
       run: |
@@ -47,7 +47,7 @@ jobs:
         python -We:invalid -m compileall -f -q lib/ etc/;
     - name: pytest
       run: |
-        python -m pytest --cov=pyflyby --cov-report=xml --doctest-modules lib tests
+        python -m pytest --cov=pyflyby --cov-report=xml --doctest-modules --maxfail=15 lib tests
     - uses: codecov/codecov-action@v2
     - name: Build docs
       if: ${{ matrix.python-version == '3.9'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       if: ${{ matrix.python-version != '2.7'}}
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade "pexpect>=3.3" pyflakes 'pytest<7' rlipython ipykernel==5.4.3 requests jupyter flaky flake8 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3' 'ipython<8'
+        python -m pip install --upgrade "pexpect>=3.3" pyflakes 'pytest<7' rlipython ipykernel==5.4.3 requests jupyter flaky flake8 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3' 'ipython<8' 'coverage<6.3'
         pip install -e .
     - name: test release build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,13 @@ jobs:
       if: ${{ matrix.python-version == '2.7'}}
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade "pexpect>=3.3" pyflakes pytest epydoc rlipython requests jupyter flaky flake8 wheel 'pytest-cov<3'
+        python -m pip install --upgrade "pexpect>=3.3" pyflakes 'pytest<7' epydoc rlipython requests jupyter flaky flake8 wheel 'pytest-cov<3'
         pip install -e .
     - name: Install and update Python dependencies on Python 3
       if: ${{ matrix.python-version != '2.7'}}
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade "pexpect>=3.3" pyflakes pytest rlipython ipykernel==5.4.3 requests jupyter flaky flake8 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3'
+        python -m pip install --upgrade "pexpect>=3.3" pyflakes 'pytest<7' rlipython ipykernel==5.4.3 requests jupyter flaky flake8 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3'
         pip install -e .
     - name: test release build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         python -We:invalid -m compileall -f -q lib/ etc/;
     - name: pytest
       run: |
-        python -m pytest --cov=pyflyby --cov-report=xml --doctest-modules --maxfail=15 lib tests
+        python -m pytest --cov=pyflyby --cov-report=xml --doctest-modules --maxfail=3 lib tests
     - uses: codecov/codecov-action@v2
     - name: Build docs
       if: ${{ matrix.python-version == '3.9'}}

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -851,7 +851,7 @@ def enable_sigterm_handler(on_existing_handler='raise'):
         return
     elif on_existing_handler == "raise":
         raise ValueError(
-            "enable_sigterm_handler(on_existing_handler='raise'): SIGTERM handler already exists")
+            "enable_sigterm_handler(on_existing_handler='raise'): SIGTERM handler already exists" + repr(old_handler))
     else:
         raise ValueError(
             "enable_sigterm_handler(): SIGTERM handler already exists, "


### PR DESCRIPTION
The newest version of pytest seem to be triggering issues in CI.
Pin for now

We also pin IPython, and coverage. Coverage 6.3+ adds a sigterm handler that make us fail. It will have to be fixed later.