### PR TITLE
Fix TypeIgnore has no col_offset.

### DIFF
--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -505,6 +505,7 @@ def test_PythonBlock_flags_type_comment_1():
         dedent(
             """
     a = 1 # type: int
+    b = None # type: ignore
     """
         ).lstrip()
     )
@@ -551,6 +552,22 @@ def test_PythonBlock_flags_type_comment_fail_transform():
          pass""")
     )
 
+    s = SourceToSourceFileImportsTransformation(block)
+    assert s.output() == block
+
+
+
+def test_PythonBlock_flags_type_comment_ignore_fails_transform():
+    """
+    See https://github.com/deshaw/pyflyby/issues/174
+
+    Type: ignore are custom ast.AST who have no col_offset.
+    """
+    block = PythonBlock(
+    dedent("""
+        a = None # type: ignore
+        """
+    ))
     s = SourceToSourceFileImportsTransformation(block)
     assert s.output() == block
 


### PR DESCRIPTION
Fixes #174 

It might introduce some unwanted reformatting around those type comments. 
We can try to submit a patch to CPython adding col_offset to TypeIgnore if you wish to do so.