### PR TITLE
Fix false positive from assigning attribute to function

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -625,6 +625,8 @@ class _MissingImportFinder(object):
             old_in_FunctionDef = self._in_FunctionDef
             self._in_FunctionDef = True
             with self._NewScopeCtx(unhide_classdef=True):
+                if not self._in_class_def:
+                    self._visit_Store(node.name)
                 self.visit(node.body)
             self._in_FunctionDef = old_in_FunctionDef
         self._visit_Store(node.name)

--- a/tests/test_imports2s.py
+++ b/tests/test_imports2s.py
@@ -666,6 +666,37 @@ def test_fix_unused_and_missing_imports_ClassDef_1():
     assert output == expected
 
 
+def test_fix_missing_imports_in_non_method():
+    """
+    unlike test_fix_unused_and_missing_imports_ClassDef_1
+    Free standing functions can refer to themselves.
+
+    Currently this will not work for closure defined in
+    methods, as we'll see a class scope.
+
+    See https://github.com/deshaw/pyflyby/issues/179
+    """
+    input = PythonBlock(
+        dedent(
+            """
+            def selfref():
+                selfref.execute = True
+    """
+        ).lstrip()
+    )
+    db = ImportDB("")
+    output = fix_unused_and_missing_imports(input, db=db)
+    expected = PythonBlock(
+        dedent(
+            """
+            def selfref():
+                selfref.execute = True
+    """
+        ).lstrip()
+    )
+    assert output == expected
+
+
 def test_fix_unused_and_missing_continutation_1():
     input = PythonBlock(dedent(r'''
         a#\


### PR DESCRIPTION
closes #179.

As noted in the issue this only fix top-level function where this
happens, not local function defined inside class methods.

We could do it, but that would be a much more involved fix