### PR TITLE
misc test update.

### DIFF
--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1624,7 +1624,7 @@ def test_ipython_tab_fail_1(frontend):
         In [2]: os.foo27817796\t()
         ---------------------------------------------------------------------------
         AttributeError                            Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         AttributeError: module 'os' has no attribute 'foo27817796'
     """, frontend=frontend)
 
@@ -1706,7 +1706,7 @@ def test_no_autoimport_1():
         In [1]: b'@'+b64decode('SGVsbG8=')+b'@'
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'b64decode' is not defined
     """)
 
@@ -1785,7 +1785,7 @@ def test_reload_ext_reload_importdb_1(tmp):
         In [3]: list(combinations('abc',2))
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'combinations' is not defined
         In [4]: with open('{tmp.file}', 'a') as f:
            ...:   f.write('from itertools import combinations\\n')
@@ -1793,7 +1793,7 @@ def test_reload_ext_reload_importdb_1(tmp):
         In [5]: list(combinations('abc',2))
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'combinations' is not defined
         In [6]: %reload_ext pyflyby
         In [7]: list(combinations('abc',2))
@@ -1825,12 +1825,12 @@ def test_reload_ext_retry_failed_imports_1(tmp):
         ....
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'rhino13609135' is not defined
         In [3]: rhino13609135
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'rhino13609135' is not defined
         In [4]: %reload_ext pyflyby
         In [5]: rhino13609135
@@ -1840,7 +1840,7 @@ def test_reload_ext_retry_failed_imports_1(tmp):
         ....
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'rhino13609135' is not defined
     """, PYTHONPATH=tmp.dir, PYFLYBY_PATH=tmp.file)
 
@@ -1946,7 +1946,7 @@ def test_autoimport_pyflyby_path_1(tmp):
         In [3]: groupby
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'groupby' is not defined
     """, PYFLYBY_PATH=tmp.file)
 
@@ -2031,7 +2031,7 @@ def test_autoimport_multiple_candidates_ast_transformer_1(tmp):
         [PYFLYBY]   import foo50853429 as bar
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'bar' is not defined
     """, PYFLYBY_PATH=tmp.file)
 
@@ -2051,7 +2051,7 @@ def test_autoimport_multiple_candidates_repeated_1(tmp):
         [PYFLYBY]   import foo70603247 as bar
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'bar' is not defined
         In [3]: bar(42)
         [PYFLYBY] Multiple candidate imports for bar.  Please pick one:
@@ -2059,7 +2059,7 @@ def test_autoimport_multiple_candidates_repeated_1(tmp):
         [PYFLYBY]   import foo70603247 as bar
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'bar' is not defined
     """, PYFLYBY_PATH=tmp.file)
 
@@ -2085,7 +2085,7 @@ def test_autoimport_multiple_candidates_multiple_in_expression_1(tmp):
         [PYFLYBY]   import foo85957810 as foo
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'foo' is not defined
     """, PYFLYBY_PATH=tmp.file)
 
@@ -2106,7 +2106,7 @@ def test_autoimport_multiple_candidates_repeated_in_expression_1(tmp):
         [PYFLYBY]   import foo83958492 as bar
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'bar' is not defined
     """, PYFLYBY_PATH=tmp.file)
 
@@ -2144,7 +2144,7 @@ def test_autoimport_multiple_candidates_multi_joinpoint_1(tmp):
         [PYFLYBY]   import foo85223658 as bar
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'bar' is not defined
     """, PYFLYBY_PATH=tmp.file, autocall=True)
 
@@ -2164,7 +2164,7 @@ def test_autoimport_multiple_candidates_multi_joinpoint_repeated_1(tmp):
         [PYFLYBY]   import foo85223658 as bar
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'bar' is not defined
         In [3]: bar
         [PYFLYBY] Multiple candidate imports for bar.  Please pick one:
@@ -2172,7 +2172,7 @@ def test_autoimport_multiple_candidates_multi_joinpoint_repeated_1(tmp):
         [PYFLYBY]   import foo85223658 as bar
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'bar' is not defined
     """, PYFLYBY_PATH=tmp.file, autocall=True)
 
@@ -2278,7 +2278,7 @@ def test_complete_symbol_member_multiple_1(frontend):
         In [2]: print(base64.b64)
         ---------------------------------------------------------------------------
         AttributeError                            Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         AttributeError: module 'base64' has no attribute 'b64'
     """, frontend=frontend)
 
@@ -2295,7 +2295,7 @@ def test_complete_symbol_member_partial_multiple_1(frontend):
         In [2]: print(base64.b64)
         ---------------------------------------------------------------------------
         AttributeError                            Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         AttributeError: module 'base64' has no attribute 'b64'
     """, frontend=frontend)
 
@@ -2436,7 +2436,7 @@ def test_complete_symbol_bad_1(frontend, tmp):
         ....
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'foo_31221052_bar' is not defined
     """, PYFLYBY_PATH=tmp.file, frontend=frontend)
 
@@ -2452,7 +2452,7 @@ def test_complete_symbol_bad_as_1(frontend, tmp):
         ....
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'bar_98073069_quux' is not defined
     """, PYFLYBY_PATH=tmp.file, frontend=frontend)
 
@@ -2618,7 +2618,7 @@ def test_disable_reenable_autoimport_1():
         In [5]: b64decode('cmVk')        # expect NameError since no auto importer
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'b64decode' is not defined
         In [6]: b64encode(b'green')       # should still work because already imported
         Out[6]: b'Z3JlZW4='
@@ -2641,7 +2641,7 @@ def test_disable_reenable_completion_1():
         In [5]: b64deco\t('Y2xvdWQ=') # expect NameError since no auto importer
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'b64deco' is not defined
         In [6]: b64enco\tde(b'tree') # should still work because already imported
         Out[6]: b'dHJlZQ=='
@@ -2683,12 +2683,12 @@ def test_error_during_auto_import_symbol_1(tmp):
         [PYFLYBY] Disabling pyflyby auto importer.
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'unknown_symbol_68470042' is not defined
         In [5]: unknown_symbol_76663387
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'unknown_symbol_76663387' is not defined
     """, PYFLYBY_PATH=tmp.file)
 
@@ -2707,12 +2707,12 @@ def test_error_during_auto_import_expression_1(tmp):
         [PYFLYBY] Disabling pyflyby auto importer.
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'unknown_symbol_72161870' is not defined
         In [5]: 42+unknown_symbol_48517397
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'unknown_symbol_48517397' is not defined
     """, PYFLYBY_PATH=tmp.file)
 
@@ -2733,14 +2733,14 @@ def test_error_during_completion_1(frontend, tmp):
         In [4]: unknown_symbol_14954304_\x06foo
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'unknown_symbol_14954304_foo' is not defined
         In [5]: 200
         Out[5]: 200
         In [6]: unknown_symbol_69697066_\t\x06foo
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'unknown_symbol_69697066_foo' is not defined
         In [7]: 300
         Out[7]: 300
@@ -2884,7 +2884,7 @@ def test_run_d_donterase(tmp):
         1
         ---------------------------------------------------------------------------
         ZeroDivisionError                         Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
               4     1/0
               5     print(myvar)
         <ipython-input> in simple_f()
@@ -3067,7 +3067,7 @@ def test_noninteractive_timeit_unaffected_1():
         [PYFLYBY] import timeit
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         ....
         NameError: global name 'base64' is not defined
     """)
@@ -3176,7 +3176,7 @@ def test_noninteractive_profile_unaffected_1():
         [PYFLYBY] import profile
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         ....
         NameError: name 'base64' is not defined
     """)
@@ -3198,7 +3198,7 @@ def test_error_during_enable_1():
         In [5]: sys
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'sys' is not defined
         In [6]: pyflyby.enable_auto_importer()
         [PYFLYBY] Not reattempting to enable auto importer after earlier error
@@ -3282,7 +3282,7 @@ def test_ipython_kernel_console_multiple_existing_1():
             In [1]: b64decode('x')
             ---------------------------------------------------------------------------
             NameError                                 Traceback (most recent call last)
-            <ipython-input> in <module>
+            <ipython-input> in ...
             NameError: name 'b64decode' is not defined
         """, args=['console'], kernel=kernel)
         # Enable the auto importer.
@@ -3327,7 +3327,7 @@ def test_ipython_notebook_1():
             In [1]: b64decode('x')
             ---------------------------------------------------------------------------
             NameError                                 Traceback (most recent call last)
-            <ipython-input> in <module>
+            <ipython-input> in ...
             NameError: name 'b64decode' is not defined
             In [2]: import pyflyby; pyflyby.enable_auto_importer()
             In [3]: b64deco\tde('aGF6ZWxudXQ=')
@@ -3351,7 +3351,7 @@ def test_ipython_notebook_reconnect_1():
             In [1]: b64decode('x')
             ---------------------------------------------------------------------------
             NameError                                 Traceback (most recent call last)
-            <ipython-input> in <module>
+            <ipython-input> in ...
             NameError: name 'b64decode' is not defined
         """, args=['console'], kernel=kernel)
         # Enable the auto importer.
@@ -3440,7 +3440,7 @@ def test_py_console_existing_1():
             In [1]: b64decode('x')
             ---------------------------------------------------------------------------
             NameError                                 Traceback (most recent call last)
-            <ipython-input> in <module>
+            <ipython-input> in ...
             NameError: name 'b64decode' is not defined
         """, prog="py", args=['console'], kernel=kernel)
 
@@ -3474,7 +3474,7 @@ def test_py_disable_1():
         In [3]: b64encode(b'x')
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'b64encode' is not defined
         In [4]: b64decode('bW9ja2VybnV0')
         Out[4]: b'mockernut'
@@ -3505,7 +3505,7 @@ def test_installed_in_config_ipython_cmdline_1(tmp):
         In [1]: b64decode('x')
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'b64decode' is not defined
     """)
 
@@ -3525,7 +3525,7 @@ def test_installed_in_config_redundant_1(tmp):
         In [1]: b64decode('x')
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'b64decode' is not defined
     """)
 
@@ -3595,7 +3595,7 @@ def test_installed_in_config_disable_1(tmp):
         In [3]: b64encode(b'x')
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'b64encode' is not defined
         In [4]: b64decode('d2lsbG93')
         Out[4]: b'willow'
@@ -3621,7 +3621,7 @@ def test_installed_in_config_enable_noop_1(tmp):
         In [4]: b64encode(b'x')
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'b64encode' is not defined
         In [5]: b64decode('YmlyY2g=')
         Out[5]: b'birch'
@@ -3645,7 +3645,7 @@ def test_installed_in_config_ipython_py_1(tmp):
         In [3]: b64encode(b'x')
         ---------------------------------------------------------------------------
         NameError                                 Traceback (most recent call last)
-        <ipython-input> in <module>
+        <ipython-input> in ...
         NameError: name 'b64encode' is not defined
         In [4]: b64decode('YnV0dGVybnV0')
         Out[4]: b'butternut'

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -966,7 +966,7 @@ def test_str_lineno_expression():
             In [1]: b64decode('x')
             ---------------------------------------------------------------------------
             NameError                                 Traceback (most recent call last)
-            <ipython-input> in <module>()
+            <ipython-input> in ...
             NameError: name 'b64decode' is not defined"""
             # Enable the auto importer.
             """


### PR DESCRIPTION
Newer IPython have different error messages with interactive code,
and have `<cell line: X>` instead of `<module>`

Replacing by `...` to be compatible with both 7.x and 8.x