### PR TITLE
Enhance debugger() work with threading.ExceptHookArgs

### DIFF
--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -479,6 +479,14 @@ def debugger(*args, **kwargs):
         _debug_exception(arg, tty=tty)
         on_continue()
         return
+    import threading
+    # If `arg` is an instance of `tuple` that contains
+    # `threading.ExceptHookArgs`, extract the exc_info from it.
+    if type(arg) is tuple and len(arg) == 1 and type(arg[0]) is threading.ExceptHookArgs:
+        arg = arg[0][:3]
+        _debug_exception(arg, tty=tty)
+        on_continue()
+        return
     if not isinstance(arg, FrameType):
         raise TypeError(
             "debugger(): expected a frame/traceback/str/code; got %s"


### PR DESCRIPTION
threading.excepthook receives a tuple of threading.ExceptHookArgs and it contains the exc_info along with the thread object. Earlier calling debugger() at this frame wasn't working and fixed in this commit. We now extract only the exc_info and continue with debugging.