### PR TITLE
Fix and test 162 (kwargs annotation not visited).

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -701,9 +701,15 @@ class _MissingImportFinder(object):
             self.visit(node.kwonlyargs)
         if sys.version_info >= (3, 8):
             self.visit(node.posonlyargs)
-        # Store vararg/kwarg names.
-        self._visit_Store(node.vararg)
-        self._visit_Store(node.kwarg)
+        # may be None.
+        if node.vararg and PY3:
+            self.visit(node.vararg)
+        else:
+            self._visit_Store(node.vararg)
+        if node.kwarg and PY3:
+            self.visit(node.kwarg)
+        else:
+            self._visit_Store(node.kwarg)
 
     def visit_ExceptHandler(self, node):
         assert node._fields == ('type', 'name', 'body')

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -277,6 +277,22 @@ def test_find_missing_imports_function_defaults_kwargs_1():
     result   = _dilist2strlist(result)
     expected = ['args', 'kwargs', 'y']
     assert expected == result
+    
+@pytest.mark.skipif(
+    PY2,
+    reason="Python 3-only syntax.")
+def test_find_missing_imports_kwarg_annotate():
+    """
+    pfb issue 162
+    """
+    code = dedent("""
+        def func_pfb162(args:Dict, **kwargs:Any):
+            pass
+    """)
+    result   = find_missing_imports(code, [{}])
+    result   = _dilist2strlist(result)
+    expected = ['Any', 'Dict']
+    assert expected == result
 
 
 def test_find_missing_imports_function_defaults_kwargs_2():


### PR DESCRIPTION
It seem the this code was initially written before type annotation and
was calling privates methods. Now we should properly get all
annotations.

Closes #162 