### PR TITLE
remove extra comma from python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ setup(
         "Programming Language :: Python",
     ],
     install_requires=["pyflakes", "six", "toml", "pathlib ; python_version<'3'"],
-    python_requires=">=2.5, !=3.0.*, !=3.1.*, !=3.2.*, !=3.2.*, !=3.3.*, !=3.4.*,, !=3.5.*, !=3.6.*, <4",
+    python_requires=">=2.5, !=3.0.*, !=3.1.*, !=3.2.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, <4",
     tests_require=['pexpect>=3.3', 'pytest', 'epydoc', 'rlipython', 'requests'],
     cmdclass = {
         'test'           : PyTest,


### PR DESCRIPTION
This extra comma was causing Poetry to choke when attempting to install `pyflyby`