### PR TITLE
Allow to configure per-projects default in pyprojects.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -399,6 +399,25 @@ This style is a maintenance nightmare:
 To fix such code, you can run ``tidy-imports --replace-star-imports`` to
 automatically replace star imports with the specific needed imports.
 
+Per-Project configuration of tidy-imports
+=========================================
+
+You can configure Pyflyby on a per-repository basis by using the
+`[tool.pyflyby]` section of `pyproject.toml` files. Pyflyby will look in current
+working directory and all it's parent until it find a `pyproject.toml` file from
+which it will load the defaults.
+
+
+Most of the long command line flags default values can be configured in this
+section. Simply use the long form option name by replacing dashes `-` by
+underscore `_`. For long option that have the form `--xxx` and `--no-xxx`, you
+can assign a boolean to `xxx`. For example::
+
+    [tool.pyflyby]
+    add_missing=true
+    from_spaces=7
+    remove_unused=false
+
 
 Emacs support
 =============
@@ -429,3 +448,6 @@ License
 
 Pyflyby is released under a very permissive license, the MIT/X11 license; see
 LICENSE.txt.
+
+
+

--- a/bin/tidy-imports
+++ b/bin/tidy-imports
@@ -25,6 +25,7 @@ from __future__ import print_function, absolute_import, division, with_statement
 from   distutils.spawn          import find_executable
 import subprocess
 import sys
+import os
 
 from   pyflyby._cmdline         import hfmt, parse_args, process_actions
 from   pyflyby._imports2s       import (canonicalize_imports,
@@ -33,88 +34,138 @@ from   pyflyby._imports2s       import (canonicalize_imports,
                                         transform_imports)
 from   pyflyby._log             import logger
 
+if sys.version_info[0] == 3:
+    # can't install/import it on Python 2
+    try:
+        import toml
+        TOML_AVAIL = True
+    except ModuleNotFoundError:
+        TOML_AVAIL = False
 
+else:
+    TOML_AVAIL = False
+
+
+
+def _get_pyproj_toml_config():
+    """
+    Try to find current project pyproject.toml
+    in cwd or parents directories.
+    """
+    if not TOML_AVAIL:
+        return None
+
+    from pathlib import Path
+
+
+    cwd = Path(os.getcwd())
+
+
+    for pth in [cwd] + list(cwd.parents):
+        pyproj_toml = pth /'pyproject.toml'
+        if pyproj_toml.exists() and pyproj_toml.is_file():
+            return pyproj_toml.read_text()
+
+    return None
+
+
+
+
+
+def _addopts(parser):
+    """
+    Callbacks to the parser to fill in extra options.
+    """
+    parser.add_option('--add-missing',
+                        default=True, action='store_true',
+                        help=hfmt('''
+                            (Default) Add missing imports.'''))
+    parser.add_option('--no-add-missing', dest='add_missing',
+                        default=True, action='store_false',
+                        help=hfmt('''
+                            Don't add missing imports.'''))
+    parser.add_option('--remove-unused',
+                        default="AUTOMATIC", action='store_true',
+                        help=hfmt('''
+                            Remove unused imports
+                            (default unless filename == __init__.py).'''))
+    parser.add_option('--no-remove-unused', dest='remove_unused',
+                        action='store_false',
+                        help=hfmt('''
+                            Don't remove unused imports
+                            (default if filename == __init__.py).'''))
+    parser.add_option('--add-mandatory',
+                        default=True, action='store_true',
+                        help=hfmt('''
+                            (Default) Add mandatory imports.'''))
+    parser.add_option('--no-add-mandatory', dest='add_mandatory',
+                        default=True, action='store_false',
+                        help=hfmt('''
+                            Don't add mandatory imports.'''))
+    parser.add_option('--replace-star-imports',
+                        default=False, action='store_true',
+                        help=hfmt('''
+                            Replace 'from foo.bar import *' with full list
+                            of imports before removing unused imports.'''))
+    parser.add_option('--no-replace-star-imports',
+                        dest='replace_star_imports',
+                        action='store_false',
+                        help=hfmt('''
+                            (Default) Don't replace 'from foo.bar import
+                            *'.'''))
+    parser.add_option('--canonicalize',
+                        default=True, action='store_true',
+                        help=hfmt('''
+                            (Default) Replace imports with canonical
+                            equivalent imports, according to database.'''))
+    parser.add_option('--no-canonicalize', dest='canonicalize',
+                        default=True, action='store_false',
+                        help=hfmt('''
+                            Don't canonicalize imports.'''))
+    parser.add_option('--py23-fallback', dest='py23_fallback',
+                        default=False, action='store_true',
+                        help=hfmt('''
+                            Automatically fallback to python2/python3 if the
+                            source file has a syntax error.'''))
+    parser.add_option('--no-py23-fallback', dest='py23_fallback',
+                        action='store_false',
+                        help=hfmt('''
+                            (Default) Do not automatically fallback to
+                            python2/python3 if the source file has a syntax
+                            error.'''))
+
+
+    def transform_callback(option, opt_str, value, group):
+        k, v = value.split("=", 1)
+        group.values.transformations[k] = v
+    parser.add_option("--transform", action='callback',
+                        type="string", callback=transform_callback,
+                        metavar="OLD=NEW",
+                        dest="transformations", default={},
+                        help=hfmt('''
+                            Replace OLD with NEW in imports.
+                            May be specified multiple times.'''))
+    def no_add_callback(option, opt_str, value, group):
+        group.values.add_missing = False
+        group.values.add_mandatory = False
+    parser.add_option('--no-add', action='callback',
+                        callback=no_add_callback,
+                        help=hfmt('''
+                            Equivalent to --no-add-missing
+                            --no-add-mandatory.'''))
 def main():
-    def addopts(parser):
-        parser.add_option('--add-missing',
-                          default=True, action='store_true',
-                          help=hfmt('''
-                              (Default) Add missing imports.'''))
-        parser.add_option('--no-add-missing', dest='add_missing',
-                          default=True, action='store_false',
-                          help=hfmt('''
-                              Don't add missing imports.'''))
-        parser.add_option('--remove-unused',
-                          default="AUTOMATIC", action='store_true',
-                          help=hfmt('''
-                              Remove unused imports
-                              (default unless filename == __init__.py).'''))
-        parser.add_option('--no-remove-unused', dest='remove_unused',
-                          action='store_false',
-                          help=hfmt('''
-                              Don't remove unused imports
-                              (default if filename == __init__.py).'''))
-        parser.add_option('--add-mandatory',
-                          default=True, action='store_true',
-                          help=hfmt('''
-                              (Default) Add mandatory imports.'''))
-        parser.add_option('--no-add-mandatory', dest='add_mandatory',
-                          default=True, action='store_false',
-                          help=hfmt('''
-                              Don't add mandatory imports.'''))
-        parser.add_option('--replace-star-imports',
-                          default=False, action='store_true',
-                          help=hfmt('''
-                              Replace 'from foo.bar import *' with full list
-                              of imports before removing unused imports.'''))
-        parser.add_option('--no-replace-star-imports',
-                          dest='replace_star_imports',
-                          action='store_false',
-                          help=hfmt('''
-                              (Default) Don't replace 'from foo.bar import
-                              *'.'''))
-        parser.add_option('--canonicalize',
-                          default=True, action='store_true',
-                          help=hfmt('''
-                              (Default) Replace imports with canonical
-                              equivalent imports, according to database.'''))
-        parser.add_option('--no-canonicalize', dest='canonicalize',
-                          default=True, action='store_false',
-                          help=hfmt('''
-                              Don't canonicalize imports.'''))
-        parser.add_option('--py23-fallback', dest='py23_fallback',
-                         default=False, action='store_true',
-                         help=hfmt('''
-                             Automatically fallback to python2/python3 if the
-                             source file has a syntax error.'''))
-        parser.add_option('--no-py23-fallback', dest='py23_fallback',
-                         action='store_false',
-                         help=hfmt('''
-                             (Default) Do not automatically fallback to
-                             python2/python3 if the source file has a syntax
-                             error.'''))
 
+    config_text = _get_pyproj_toml_config()
+    if config_text:
+        default_config = toml.loads(config_text).get('tool', {}).get('pyflyby',{})
+    else:
+        default_config = {}
 
-        def transform_callback(option, opt_str, value, group):
-            k, v = value.split("=", 1)
-            group.values.transformations[k] = v
-        parser.add_option("--transform", action='callback',
-                          type="string", callback=transform_callback,
-                          metavar="OLD=NEW",
-                          dest="transformations", default={},
-                          help=hfmt('''
-                                Replace OLD with NEW in imports.
-                                May be specified multiple times.'''))
-        def no_add_callback(option, opt_str, value, group):
-            group.values.add_missing = False
-            group.values.add_mandatory = False
-        parser.add_option('--no-add', action='callback',
-                          callback=no_add_callback,
-                          help=hfmt('''
-                              Equivalent to --no-add-missing
-                              --no-add-mandatory.'''))
+    def _add_opts_and_defaults(parser):
+        _addopts(parser)
+        parser.set_defaults(**default_config)
     options, args = parse_args(
-        addopts, import_format_params=True, modify_action_params=True)
+        _add_opts_and_defaults, import_format_params=True, modify_action_params=True, defaults=default_config)
     def modify(x):
         if options.canonicalize:
             x = canonicalize_imports(x, params=options.params)

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -39,10 +39,16 @@ def _sigpipe_handler(*args):
     raise SystemExit(1)
 
 
-def parse_args(addopts=None, import_format_params=False, modify_action_params=False):
+def parse_args(
+    addopts=None, import_format_params=False, modify_action_params=False, defaults=None
+):
     """
     Do setup for a top-level script and parse arguments.
     """
+
+    if defaults is None:
+        defaults = {}
+
     ### Setup.
     # Register a SIGPIPE handler.
     signal.signal(signal.SIGPIPE, _sigpipe_handler)

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
     ],
-    install_requires=['pyflakes', 'six'],
+    install_requires=["pyflakes", "six", "toml", "pathlib ; python_version<'3'"],
     python_requires=">=2.5, !=3.0.*, !=3.1.*, !=3.2.*, !=3.2.*, !=3.3.*, !=3.4.*,, !=3.5.*, !=3.6.*, <4",
     tests_require=['pexpect>=3.3', 'pytest', 'epydoc', 'rlipython', 'requests'],
     cmdclass = {


### PR DESCRIPTION
Should fix #188.

There are many options, so this should work in most cases, but I expect
edge cases.

This will likely not work on Python 2, and we may need to make toml an
optional dependency