### PR TITLE
Fix #197 – IOStream Removed.

### DIFF
--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -1329,6 +1329,13 @@ def UpdateIPythonStdioCtx():
     if "IPython" not in sys.modules:
         yield
         return
+
+    import IPython
+
+    if IPython.version_info[:1] >= (8,):
+        yield
+        return
+
     if "IPython.utils.io" in sys.modules:
         # Tested with IPython 0.11, 0.12, 0.13, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2,
         # 2.3, 2.4, 3.0, 3.1, 3.2, 4.0.

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -895,6 +895,7 @@ def IPythonCtx(prog="ipython",
         env["PYTHONSTARTUP"]     = ""
         env["MPLCONFIGDIR"]      = mplconfigdir
         env["PATH"]              = str(PYFLYBY_BIN.real) + os.path.pathsep + os.environ["PATH"]
+        env["PYTHONBREAKPOINT"]  = "IPython.terminal.debugger.set_trace"
         cmd = _build_ipython_cmd(ipython_dir, prog, args, autocall=autocall,
                                  frontend=frontend)
         # Spawn IPython.
@@ -4350,7 +4351,7 @@ def test_debug_auto_import_statement_step_1(frontend, tmp):
     reason="old IPython and Python won't work with breakpoint()",
 )
 @retry
-def test_breakpoint_IOStream_broken(frontend):
+def test_breakpoint_IOStream_broken():
     # Verify that step functionality isn't broken.
     ipython(
         '''
@@ -4358,9 +4359,11 @@ def test_breakpoint_IOStream_broken(frontend):
         --Call--
         > ...
             ...
+            ...
         --> ...     def __call__(self, result=None):
             ...         """Printing with history cache management.
+            ...
         ipdb> c
     ''',
-        frontend=frontend,
+        frontend='prompt_toolkit',
     )

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -4343,3 +4343,24 @@ def test_debug_auto_import_statement_step_1(frontend, tmp):
 # TODO: add tests for when IPython is not installed.  either using a tox
 # environment, or using a PYTHONPATH that shadows IPython with something
 # unimportable.
+
+
+@pytest.mark.skipif(
+    _IPYTHON_VERSION < (7, 0) or (sys.version_info < (3, 7)),
+    reason="old IPython and Python won't work with breakpoint()",
+)
+@retry
+def test_breakpoint_IOStream_broken(frontend):
+    # Verify that step functionality isn't broken.
+    ipython(
+        '''
+        In [1]: breakpoint()
+        --Call--
+        > ...
+            ...
+        --> ...     def __call__(self, result=None):
+            ...         """Printing with history cache management.
+        ipdb> c
+    ''',
+        frontend=frontend,
+    )


### PR DESCRIPTION
Using IOStream should be unnecessary. Just do Nothing on IPython 8 and
above. I believe could be way less conservative and don't use IOStream
for IPython 5 and above, but better be safe