### PR TITLE
remove pyflakes from install requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
     ],
-    install_requires=["pyflakes", "six", "toml", "pathlib ; python_version<'3'"],
+    install_requires=["six", "toml", "pathlib ; python_version<'3'"],
     python_requires=">=2.5, !=3.0.*, !=3.1.*, !=3.2.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, <4",
     tests_require=['pexpect>=3.3', 'pytest', 'epydoc', 'rlipython', 'requests'],
     cmdclass = {


### PR DESCRIPTION
This is an artifact from when it was used for it's AST parser.