### PR TITLE
move linting into it's own GH action.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install and update Python dependencies on Python 3
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pyflakes flake8 
+        pip install -e .
+    - name: lint
+      run: |
+        flake8 --exclude known_imports,etc,__init__.py --select=F;
+    - name: Self-tidy-import
+      run: |
+        ./bin/tidy-imports -d lib/python/ tests/
+        

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,21 +27,17 @@ jobs:
       if: ${{ matrix.python-version == '2.7'}}
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade "pexpect>=3.3" pyflakes 'pytest<7' epydoc rlipython requests jupyter flaky flake8 wheel 'pytest-cov<3'
+        python -m pip install --upgrade "pexpect>=3.3" 'pytest<7' epydoc rlipython requests jupyter flaky wheel 'pytest-cov<3'
         pip install -e .
     - name: Install and update Python dependencies on Python 3
       if: ${{ matrix.python-version != '2.7'}}
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade "pexpect>=3.3" pyflakes 'pytest<7' rlipython ipykernel==5.4.3 requests jupyter flaky flake8 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3' ipython 'coverage<6.3'
+        python -m pip install --upgrade "pexpect>=3.3" 'pytest<7' rlipython ipykernel==5.4.3 requests jupyter flaky 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3' ipython 'coverage<6.3'
         pip install -e .
     - name: test release build
       run: |
         python setup.py sdist bdist_wheel
-    - name: lint
-      if: ${{ matrix.python-version == '3.9'}}
-      run: |
-        flake8 --exclude known_imports,etc,__init__.py --select=F;
     - name: compileall
       run: |
         python -We:invalid -m compileall -f -q lib/ etc/;
@@ -56,7 +52,3 @@ jobs:
         cd doc
         make html
         cd ..
-    - name: Self-tidy-import
-      run: |
-        ./bin/tidy-imports -d lib/python/ tests/
-        


### PR DESCRIPTION
This will give faster feedback as lint is quasi immediate,
and will be a separate item in the CI result, which make it easy to see
if this is critical error, or just linting problem