### PR TITLE
Allow debugger to not kill debugging process

### DIFF
--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -1056,6 +1056,7 @@ def inject(pid, statements, wait=True, show_gdb_output=False):
     else:
         return process.pid
 
+
 import tty
 
 

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -288,7 +288,7 @@ def _prompt_continue_waiting_for_debugger():
             break
 
         if response.lower() not in ('y', 'yes'):
-            print(f"Invalid response: {repr(response)}")
+            print("Invalid response: {}".format(repr(response)))
         else:
             break
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1045,6 +1045,9 @@ def ipython(template, **kwargs):
     the template.  Assert that the result matches.
     """
     __tracebackhide__ = True
+    if sys.version_info[:2] >= (3, 8):
+      # more recent IPython have a different formatting.
+      template = template.replace("... in ...", "... line ...")
     template = dedent(template).strip()
     input, expected = parse_template(template, clear_tab_completions=_IPYTHON_VERSION>=(7,))
     args = kwargs.pop("args", ())


### PR DESCRIPTION
wait_for_debugger_to_attach leaves a process behind for attaching a debugger to it that stops as soon as the debugger is attached. To facilitate attaching more debugger after initial debugging is done, we now prompt at the end of debugging to check whether to continue waiting for the debugger to be attached and do as per the user response.