### PR TITLE
Exit with user message upon max invalid responses

### DIFF
--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -292,7 +292,8 @@ def _prompt_continue_waiting_for_debugger():
             count_invalid += 1
         else:
             break
-    print("Exiting after multiple ({}) invalid responses.".format(max_invalid_entries))
+    print("Exiting after {} invalid responses.".format(max_invalid_entries))
+    _waiting_for_debugger = None
     # Sleep for a fraction of second for the print statements to get printed.
     time.sleep(0.01)
 

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -292,6 +292,9 @@ def _prompt_continue_waiting_for_debugger():
             count_invalid += 1
         else:
             break
+    print("Exiting after multiple ({}) invalid responses.".format(max_invalid_entries))
+    # Sleep for a fraction of second for the print statements to get printed.
+    time.sleep(0.01)
 
 
 def _debug_exception(*exc_info, **kwargs):


### PR DESCRIPTION
While exiting a debugger, there is a prompt which asks user whether to keep the debugging process running or not. The prompt is for a max of 3 (as of now) invalid responses.

Added a print statement when maximum invalid responses are received indicating the exiting of debugger.