### PR TITLE
Remove matplotlib.pyplot.grid from known imports (#1)

### DIFF
--- a/etc/pyflyby/numpy.py
+++ b/etc/pyflyby/numpy.py
@@ -4,10 +4,9 @@ import matplotlib.colors
 from   matplotlib.colors        import ColorConverter
 from   matplotlib.font_manager  import FontProperties
 from   matplotlib.patches       import Rectangle
-from   matplotlib.pyplot        import (clf, draw, figure, gca, gcf, grid,
-                                        ioff, legend, plot, savefig, scatter,
-                                        show, subplot, title, xlabel, ylabel,
-                                        ylim)
+from   matplotlib.pyplot        import (clf, draw, figure, gca, gcf, ioff,
+                                        legend, plot, savefig, scatter, show,
+                                        subplot, title, xlabel, ylabel, ylim)
 from   matplotlib.ticker        import (Formatter, Locator, NullFormatter,
                                         NullLocator)
 import numexpr


### PR DESCRIPTION
This commit removes `matplotlib.pyplot.grid` from known imports.

Reason: It is very generic and can conflict with other imports.