### PR TITLE
Fix for positional only parameters

### DIFF
--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -145,9 +145,10 @@ def _iter_child_nodes_in_order_internal_1(node):
             assert node._fields == ('args', 'vararg', 'kwonlyargs',
                                     'kw_defaults', 'kwarg', 'defaults'), node._fields
         defaults = node.defaults or ()
-        num_no_default = len(node.args)-len(defaults)
-        yield node.args[:num_no_default]
-        yield list(zip(node.args[num_no_default:], defaults))
+        args = node.posonlyargs + node.args
+        num_no_default = len(args) - len(defaults)
+        yield args[:num_no_default]
+        yield list(zip(args[num_no_default:], defaults))
         # node.varags and node.kwarg are strings, not AST nodes.
     elif isinstance(node, ast.IfExp):
         assert node._fields == ('test', 'body', 'orelse')

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -141,11 +141,12 @@ def _iter_child_nodes_in_order_internal_1(node):
         elif sys.version_info >= (3, 8):
             assert node._fields == ('posonlyargs', 'args', 'vararg', 'kwonlyargs',
                                     'kw_defaults', 'kwarg', 'defaults'), node._fields
+            args = node.posonlyargs + node.args
         else:
             assert node._fields == ('args', 'vararg', 'kwonlyargs',
                                     'kw_defaults', 'kwarg', 'defaults'), node._fields
+            args = node.args
         defaults = node.defaults or ()
-        args = node.posonlyargs + node.args
         num_no_default = len(args) - len(defaults)
         yield args[:num_no_default]
         yield list(zip(args[num_no_default:], defaults))

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -138,6 +138,7 @@ def _iter_child_nodes_in_order_internal_1(node):
     elif isinstance(node, ast.arguments):
         if six.PY2:
             assert node._fields == ('args', 'vararg', 'kwarg', 'defaults'), node._fields
+            args = node.args
         elif sys.version_info >= (3, 8):
             assert node._fields == ('posonlyargs', 'args', 'vararg', 'kwonlyargs',
                                     'kw_defaults', 'kwarg', 'defaults'), node._fields

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -569,6 +569,7 @@ if PY3:
                 return await file.read()
         """
         )
+if sys.version_info >= (3, 8):
     examples_transform.append(
     # positional only
     """ 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -556,18 +556,6 @@ def test_PythonBlock_flags_type_comment_fail_transform():
     assert s.output() == block
 
 
-def test_PythonBlock_posonly():
-    block = PythonBlock(
-    dedent("""
-     def f(x, y=None, / , z=None):
-         pass""")
-    )
-
-    s = SourceToSourceFileImportsTransformation(block)
-    assert s.output() == block
-
-
-
 examples_transform = ["""
     a = None # type: ignore
     """]
@@ -580,6 +568,12 @@ if PY3:
             async with aiofiles.open(location, "rb") as file:
                 return await file.read()
         """
+        )
+    examples_transform.append(
+    # positional only
+    """ 
+    def f(x, y=None, / , z=None):
+         pass"""
         )
 
 @pytest.mark.parametrize("source", examples_transform)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -556,6 +556,17 @@ def test_PythonBlock_flags_type_comment_fail_transform():
     assert s.output() == block
 
 
+def test_PythonBlock_posonly():
+    block = PythonBlock(
+    dedent("""
+     def f(x, y=None, / , z=None):
+         pass""")
+    )
+
+    s = SourceToSourceFileImportsTransformation(block)
+    assert s.output() == block
+
+
 
 examples_transform = ["""
     a = None # type: ignore


### PR DESCRIPTION
Relatively simple fix for positional only argument

As we don't do any particular reformatting, we don't need to worry about
the positional only arguments, we just treat them at the other
positional arguments.