### PR TITLE
Revert 6ee02b8af32e9c2a23ca286024d88380c3ba0403 commit

### DIFF
--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -1203,7 +1203,6 @@ def attach_debugger(pid):
         while True:
             try:
                 if not process_exists(gdb_pid):
-                    print("GDB process has exited.")
                     kill_process(
                         parent_pid,
                         [(signal.SIGUSR1, 5), (signal.SIGTERM, 15),

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -1114,16 +1114,8 @@ def process_exists(pid):
     :rtype:
       ``bool``
     """
-    import psutil
-
     try:
         os.kill(pid, 0)
-
-        # Zombie processes should be treated as non-existing.
-        proc = psutil.Process(pid)
-        if proc.status() == psutil.STATUS_ZOMBIE:
-            return False
-
         return True
     except OSError as e:
         if e.errno == errno.ESRCH:


### PR DESCRIPTION
While attaching a debugger to already running process using '-d' option, we exit the GDB launched using inject and the debugging happens outside of the GDB.

So the GDB is exited but becomes a zombie process. But we have checks to exit the debugging if the GDB has exited. Our checks to make sure if a process is running or not doesn't treat zombie process as dead and hence it was a silent pass through earlier.

With commit 6ee02b8af32e9c2a23ca286024d88380c3ba0403 the issue got exposed. So temporarily reverting the change to prevent hampering any existing use cases.