### PR TITLE
MAINT: Cleanup and type stability,

### DIFF
--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -391,8 +391,8 @@ class ImportStatement(object):
           `ImportStatement`
         """
         if isinstance(node, ast.ImportFrom):
-            if sys.version_info[:2] < (3, 0):
-                # In python2.7, ast.parse("from . import blah") yields
+            if node.module is None:
+                # In python2.7 and 3 as well, ast.parse("from . import blah") yields
                 # node.module = None.  In python2.6, it's the empty string.
                 module = ''
             else:

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -6,9 +6,9 @@ from __future__ import (absolute_import, division, print_function,
                         with_statement)
 
 import ast
-import sys
 from   collections              import namedtuple
 from   functools                import total_ordering
+import sys
 
 from   pyflyby._flags           import CompilerFlags
 from   pyflyby._format          import FormatParams, pyfill

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, print_function,
 import ast
 from   collections              import namedtuple
 from   functools                import total_ordering
-import sys
 
 from   pyflyby._flags           import CompilerFlags
 from   pyflyby._format          import FormatParams, pyfill

--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -358,7 +358,7 @@ class ModuleHandle(object):
                     "Module %r contains non-string entries in __all__"
                     % (str(self.name),))
         # Filter out artificially added "deep" members.
-        members = [n for n in members if "." not in n]
+        members = [(n, None) for n in members if "." not in n]
         if not members:
             return None
         return ImportSet(


### PR DESCRIPTION
Try to maintain a bit of type stability to avoid branching and make reasoning a bit easier.

Make clearer error messages, and use assertions instead of custom errors/raising