### PR TITLE
Fix py --apply to work with functions with keyword-only arguments

### DIFF
--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -380,7 +380,10 @@ FLAGS = CompilerFlags(["absolute_import", "with_statement", "division",
 
 
 def _get_argspec(arg, _recurse=False):
-    from inspect import getargspec, ArgSpec
+    if sys.version_info[0] == 3:
+        from inspect import getfullargspec as getargspec, FullArgSpec as ArgSpec
+    else:
+        from inspect import getargspec, ArgSpec
     if isinstance(arg, FunctionType):
         return getargspec(arg)
     elif isinstance(arg, MethodType):
@@ -405,7 +408,10 @@ def _get_argspec(arg, _recurse=False):
         return _get_argspec(arg.__call__, _recurse=False)
     elif callable(arg):
         # Unknown, probably a built-in method.
-        return ArgSpec((), "args", "kwargs", None)
+        if sys.version_info[0] == 3:
+            return ArgSpec((), "args", "kwargs", None, [], None, {})
+        else:
+            return ArgSpec((), "args", "kwargs", None)
     raise TypeError(
         "_get_argspec: unexpected %s" % (type(arg).__name__,))
 
@@ -497,7 +503,8 @@ def _build_function_usage_string(function_name, argspec, prefix):
     usage.append("  >"+">> " + _format_call_spec(function_name, argspec))
     usage.append("")
     usage.append("Command-line signature:")
-    if not argspec.args and argspec.varargs and argspec.keywords:
+    keywords = argspec.keywords if sys.version_info[0] == 2 else argspec.varkw
+    if not argspec.args and argspec.varargs and keywords:
         # We have no information about the arguments.  It's probably a
         # built-in where getargspec failed.
         usage.append("  $ %s%s ...\n" % (prefix, function_name))
@@ -514,7 +521,13 @@ def _build_function_usage_string(function_name, argspec, prefix):
     if argspec.varargs:
         syntax1 += " %s..." % argspec.varargs
     syntax1 += "]" * len(defaults)
-    if argspec.keywords:
+    if sys.version_info[0] == 3:
+        for arg in argspec.kwonlyargs:
+            if argspec.kwonlydefaults and arg in argspec.kwonlydefaults:
+                syntax1 += " [--%s=...]" % (arg,)
+            else:
+                syntax1 += " --%s=..." % (arg,)
+    if keywords:
         syntax1 += " [--...]"
     usage.append(syntax1)
     # usage.append("or:")
@@ -524,9 +537,15 @@ def _build_function_usage_string(function_name, argspec, prefix):
             syntax2 += " [--%s=...]" % (arg,)
         else:
             syntax2 += " --%s=..." % (arg,)
+    if sys.version_info[0] == 3:
+        for arg in argspec.kwonlyargs:
+            if argspec.kwonlydefaults and arg in argspec.kwonlydefaults:
+                syntax2 += " [--%s=...]" % (arg,)
+            else:
+                syntax2 += " --%s=..." % (arg,)
     if argspec.varargs:
         syntax2 += " %s..." % argspec.varargs
-    if argspec.keywords:
+    if keywords:
         syntax2 += " [--...]"
     usage.append(syntax2)
     usage.append("")
@@ -704,12 +723,20 @@ def _parse_auto_apply_args(argspec, commandline_args, namespace, arg_mode="auto"
     for argname, default in zip(argspec.args[len(argspec.args)-len(defaults):],
                                 defaults):
         argname2default[argname] = make_expr(default, "raw_value")
+    if sys.version_info[0] == 3:
+        if argspec.kwonlydefaults:
+            for argname, default in argspec.kwonlydefaults.items():
+                argname2default[argname] = make_expr(default, "raw_value")
     # Create a map from prefix to arguments with that prefix.  E.g. {"foo":
     # ["foobar", "foobaz"]}
     prefix2argname = {}
     for argname in argspec.args:
         for prefix in prefixes(argname):
             prefix2argname.setdefault(prefix, []).append(argname)
+    if sys.version_info[0] == 3:
+        for argname in argspec.kwonlyargs:
+            for prefix in prefixes(argname):
+                prefix2argname.setdefault(prefix, []).append(argname)
     # Enumerate over input arguments.
     got_pos_args = []
     got_keyword_args = {}
@@ -748,8 +775,15 @@ def _parse_auto_apply_args(argspec, commandline_args, namespace, arg_mode="auto"
                         raise _ParseInterruptedWantHelp
                     if argname in ["source"]:
                         raise _ParseInterruptedWantSource
-                if not argspec.keywords:
-                    raise ParseError("Unknown option name %s" % (argname,))
+                if sys.version_info[0] == 3:
+                    if not argspec.varkw and not argspec.kwonlyargs:
+                        raise ParseError("Unknown option name %s" %
+                                         (argname,))
+                else:
+                    if not argspec.keywords:
+                        raise ParseError("Unknown option name %s" %
+                                         (argname,))
+
             elif len(matched_argnames) > 1:
                 raise ParseError(
                     "Ambiguous %s: could mean one of: %s"
@@ -798,6 +832,25 @@ def _parse_auto_apply_args(argspec, commandline_args, namespace, arg_mode="auto"
                 "Error parsing value for --%s=%s: %s: %s"
                 % (argname, expr, type(e).__name__, e))
         parsed_args.append(value)
+
+    if sys.version_info[0] == 3:
+        for argname in argspec.kwonlyargs:
+            try:
+                expr = got_keyword_args.pop(argname)
+            except KeyError:
+                try:
+                    expr = argname2default[argname]
+                except KeyError:
+                    raise ParseError(
+                        "missing required keyword argument %s" % (argname,))
+
+            try:
+                value = expr.value
+            except Exception as e:
+                raise ParseError(
+                    "Error parsing value for --%s=%s: %s: %s"
+                    % (argname, expr, type(e).__name__, e))
+            parsed_kwargs[argname] = value
 
     if len(got_pos_args) > len(argspec.args):
         if argspec.varargs:

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -372,6 +372,90 @@ def test_apply_kwargs_1():
     assert expected == result
 
 
+@pytest.mark.skipif(
+    sys.version_info[0] != 3, reason="keyword-only args require Python 3"
+)
+def test_apply_kwonlyargs_1():
+    result = py("--apply", "lambda x, *, y: x + y", "2", "--y=3")
+    expected = dedent("""
+        [PYFLYBY] (lambda x, *, y: x + y)(2, y=3)
+        5
+    """).strip()
+    assert expected == result
+
+
+@pytest.mark.skipif(
+    sys.version_info[0] != 3, reason="keyword-only args require Python 3"
+)
+def test_apply_kwonlyargs_2():
+    result = py("--apply", "lambda x, *, y, z=1: x + y + z", "2", "--y=3")
+    expected = dedent("""
+        [PYFLYBY] (lambda x, *, y, z=1: x + y + z)(2, y=3, z=1)
+        6
+    """).strip()
+    assert expected == result
+
+
+@pytest.mark.skipif(
+    sys.version_info[0] != 3, reason="keyword-only args require Python 3"
+)
+def test_apply_kwonlyargs_3():
+    result = py("--apply", "lambda x, *, y, z=1: x + y + z", "2", "--y=3", "--z=4")
+    expected = dedent("""
+        [PYFLYBY] (lambda x, *, y, z=1: x + y + z)(2, y=3, z=4)
+        9
+    """).strip()
+    assert expected == result
+
+
+@pytest.mark.skipif(
+    sys.version_info[0] != 3, reason="keyword-only args require Python 3"
+)
+def test_apply_kwonlyargs_4():
+    result = py("--apply", "lambda x, *, y, z=1: x + y + z", "2", "3")
+    expected = dedent("""
+        [PYFLYBY] missing required keyword argument y
+
+        Python signature:
+          >>> (lambda x, *, y, z=1: x + y + z)(x, *, y, z=1)
+
+        Command-line signature:
+          $ py 'lambda x, *, y, z=1: x + y + z' x --y=... [--z=...]
+          $ py 'lambda x, *, y, z=1: x + y + z' --x=... --y=... [--z=...]
+
+        Filename:
+          <unknown>
+
+        Docstring:
+          (No docstring)
+    """).strip(), 1
+    assert expected == result
+
+
+@pytest.mark.skipif(
+    sys.version_info[0] != 3, reason="keyword-only args require Python 3"
+)
+def test_apply_kwonlyargs_5():
+    result = py("--apply", "lambda x, *, y, z=1: x + y + z", "2", "--z=3")
+    expected = dedent("""
+        [PYFLYBY] missing required keyword argument y
+
+        Python signature:
+          >>> (lambda x, *, y, z=1: x + y + z)(x, *, y, z=1)
+
+        Command-line signature:
+          $ py 'lambda x, *, y, z=1: x + y + z' x --y=... [--z=...]
+          $ py 'lambda x, *, y, z=1: x + y + z' --x=... --y=... [--z=...]
+
+        Filename:
+          <unknown>
+
+        Docstring:
+          (No docstring)
+    """).strip(), 1
+    assert expected == result
+
+
 def test_apply_print_function_1():
     result = py("--apply", "print", "50810461")
     expected = dedent("""


### PR DESCRIPTION
Fixes #226 (PyInf#9140)