### PR TITLE
Fix autoimport with Python 3 namespace packages

### DIFF
--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -208,7 +208,7 @@ class ModuleHandle(object):
         # pkgutil.find_loader returns None for unimported Python 3
         # namespace packages, so prefer importlib
         try:
-            import importlib
+            import importlib.util
             find = importlib.util.find_spec
         except ImportError:
             import pkgutil

--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -204,15 +204,24 @@ class ModuleHandle(object):
             return True
         if self.parent and not self.parent.exists:
             return False
-        import pkgutil
+
+        # pkgutil.find_loader returns None for unimported Python 3
+        # namespace packages, so prefer importlib
         try:
-            loader = pkgutil.find_loader(name)
+            import importlib
+            find = importlib.util.find_spec
+        except ImportError:
+            import pkgutil
+            find = pkgutil.find_loader
+
+        try:
+            pkg = find(name)
         except Exception:
             # Catch all exceptions, not just ImportError.  If the __init__.py
             # for the parent package of the module raises an exception, it'll
             # propagate to here.
-            loader = None
-        return loader is not None
+            pkg = None
+        return pkg is not None
 
     @cached_attribute
     def filename(self):

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -2122,3 +2122,15 @@ def test_post_import_hook_fullname():
     def test_hook(val):
         assert val == expected
     auto_import("numpy.compat", [{}], db=db, post_import_hook=test_hook)
+
+@pytest.mark.skipif(
+    PY2,
+    reason="Python 3-only namespace package.")
+def test_namespace_package(tpp, capsys):
+    os.mkdir(str(tpp/'namespace_package'))
+    auto_import("namespace_package", [{}])
+    out, _ = capsys.readouterr()
+    expected = dedent("""
+        [PYFLYBY] import namespace_package
+    """).lstrip()
+    assert out.startswith(expected)


### PR DESCRIPTION
The legacy pkgutil cannot find them if they haven't been imported yet, so we prefer importlib instead to detect if a package exists.

Fixes #146.