### PR TITLE
Add timeout to avoid stalled MacOS builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Some MacOS builds stalls and times out after 6 hours, adding this to avoid long stalling builds. See #235 (not a fix but work around for faster feedback and avoid hogging CI)

Example: https://github.com/deshaw/pyflyby/actions/runs/4718734280/jobs/8368673242