### PR TITLE
Add a few known imports from collections.abc and typing

### DIFF
--- a/etc/pyflyby/std.py
+++ b/etc/pyflyby/std.py
@@ -17,6 +17,8 @@ import cProfile
 import cgi
 import collections
 from   collections              import defaultdict, deque, namedtuple
+import collections.abc
+from   collections.abc          import Collection, Iterable, Iterator, Sequence
 import commands
 import contextlib
 from   contextlib               import closing, contextmanager, nested
@@ -317,6 +319,8 @@ from   types                    import (BooleanType, BufferType,
                                         TracebackType, TupleType, TypeType,
                                         UnboundMethodType, UnicodeType,
                                         XRangeType)
+import typing
+from   typing                   import NamedTuple, Optional, Protocol
 import unittest
 import urllib
 import urllib2


### PR DESCRIPTION
These are useful for writing type annotated Python.