### PR TITLE
Skip unsafe filename instead of disabling pyflyby

### DIFF
--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -14,7 +14,6 @@ import sys
 from   six                      import string_types
 
 from   pyflyby._util            import cached_attribute, cmp, memoize
-from   pyflyby._log             import logger
 
 
 class UnsafeFilenameError(ValueError):

--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -47,9 +47,9 @@ class Filename(object):
         if not filename:
             raise UnsafeFilenameError("(empty string)")
         if re.search("[^a-zA-Z0-9_=+{}/.,~@-]", filename):
-            logger.warning(f"Warning: Unsafe filename: {filename}")
+            raise UnsafeFilenameError(filename)
         if re.search("(^|/)~", filename):
-            logger.warning(f"Warning: Unsafe filename: {filename}")
+            raise UnsafeFilenameError(filename)
         self = object.__new__(cls)
         self._filename = os.path.abspath(filename)
         return self

--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -14,6 +14,8 @@ import sys
 from   six                      import string_types
 
 from   pyflyby._util            import cached_attribute, cmp, memoize
+from   pyflyby._log             import logger
+
 
 class UnsafeFilenameError(ValueError):
     pass
@@ -45,9 +47,9 @@ class Filename(object):
         if not filename:
             raise UnsafeFilenameError("(empty string)")
         if re.search("[^a-zA-Z0-9_=+{}/.,~@-]", filename):
-            raise UnsafeFilenameError(filename)
+            logger.warning(f"Warning: Unsafe filename: {filename}")
         if re.search("(^|/)~", filename):
-            raise UnsafeFilenameError(filename)
+            logger.warning(f"Warning: Unsafe filename: {filename}")
         self = object.__new__(cls)
         self._filename = os.path.abspath(filename)
         return self

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -2048,3 +2048,14 @@ def test_namespace_package(tpp, capsys):
         [PYFLYBY] import namespace_package
     """).lstrip()
     assert out.startswith(expected)
+
+
+def test_unsafe_filename_warning(tpp, capsys):
+    filepath = str(tpp/'foo#bar')
+    os.mkdir(filepath)
+    auto_import("pyflyby", [{}])
+    out, _ = capsys.readouterr()
+    expected = dedent(f"""
+        [PYFLYBY] Warning: Unsafe filename: {filepath}
+    """).lstrip()
+    assert out.startswith(expected)

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -2051,11 +2051,12 @@ def test_namespace_package(tpp, capsys):
 
 
 def test_unsafe_filename_warning(tpp, capsys):
-    filepath = str(tpp/'foo#bar')
-    os.mkdir(filepath)
+    filepath = Filename(tpp._filename)
+    filepath._filename = os.path.join(filepath._filename, 'foo#bar')
+    os.mkdir(filepath._filename)
     auto_import("pyflyby", [{}])
     out, _ = capsys.readouterr()
     expected = dedent(f"""
-        [PYFLYBY] Warning: Unsafe filename: {filepath}
+        [PYFLYBY] import pyflyby
     """).lstrip()
     assert out.startswith(expected)

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -2057,7 +2057,7 @@ def test_unsafe_filename_warning(tpp, capsys):
     with CwdCtx(filepath):
         auto_import("pyflyby", [{}])
     out, _ = capsys.readouterr()
-    expected = dedent(f"""
+    expected = dedent("""
         [PYFLYBY] import pyflyby
     """).lstrip()
     assert out.startswith(expected)

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -20,6 +20,7 @@ from   pyflyby._autoimp         import (LoadSymbolError, load_symbol,
 from   pyflyby._idents          import DottedIdentifier
 from   pyflyby._importstmt      import Import
 from   pyflyby._flags           import CompilerFlags
+from pyflyby._util import CwdCtx
 
 
 @pytest.fixture
@@ -2051,10 +2052,10 @@ def test_namespace_package(tpp, capsys):
 
 
 def test_unsafe_filename_warning(tpp, capsys):
-    filepath = Filename(tpp._filename)
-    filepath._filename = os.path.join(filepath._filename, 'foo#bar')
-    os.mkdir(filepath._filename)
-    auto_import("pyflyby", [{}])
+    filepath = os.path.join(tpp._filename, 'foo#bar')
+    os.mkdir(filepath)
+    with CwdCtx(filepath):
+        auto_import("pyflyby", [{}])
     out, _ = capsys.readouterr()
     expected = dedent(f"""
         [PYFLYBY] import pyflyby


### PR DESCRIPTION
Fixes #124 

Adding a warning instead of disabling pyflyby as mentioned here: https://github.com/deshaw/pyflyby/issues/124#issuecomment-1271294384