### PR TITLE
Fix parsing of multiline strings in 3.7

### DIFF
--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -352,12 +352,8 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
     # this prevent reformatting.
     # set the column offset to the parent value before 3.8
     if (3, 7) < sys.version_info < (3, 8):
-        if (
-            isinstance(ast_node, (getattr(ast, "JoinedStr", None), ast.FormattedValue))
-            or isinstance(
-                parent_ast_node, (getattr(ast, "JoinedStr", None), ast.FormattedValue)
-            )
-        ) and ast_node.col_offset == -1:
+        instances = (getattr(ast, "JoinedStr", None), ast.FormattedValue, ast.keyword)
+        if isinstance(ast_node, instances) or isinstance(parent_ast_node, instances):
             ast_node.col_offset = parent_ast_node.col_offset
 
     # First, traverse child nodes.  If the first child node (recursively) is a

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -352,8 +352,8 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
     # this prevent reformatting.
     # set the column offset to the parent value before 3.8
     if (3, 7) < sys.version_info < (3, 8):
-        instances = (getattr(ast, "JoinedStr", None), ast.FormattedValue, ast.keyword)
-        if isinstance(ast_node, instances) or isinstance(parent_ast_node, instances):
+        instances = (getattr(ast, "JoinedStr", None), ast.FormattedValue)
+        if ((isinstance(ast_node, instances) or isinstance(parent_ast_node, instances)) and ast_node.col_offset == -1) or isinstance(ast_node, ast.keyword):
             ast_node.col_offset = parent_ast_node.col_offset
 
     # First, traverse child nodes.  If the first child node (recursively) is a

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1394,6 +1394,10 @@ def foo():
     return f"""
         {name}
     """
+''',
+'''
+func(arg=f"""
+""")
 '''
     ],
 )


### PR DESCRIPTION
The `ast`.'keyword' object has no attribute `'col_offset'`, this PR this the same. Fixes #245 