### PR TITLE
Fix prompt to keep the debuggable process alive

### DIFF
--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -288,10 +288,11 @@ def _prompt_continue_waiting_for_debugger():
             count_invalid += 1
         else:
             break
-    print("Exiting after {} invalid responses.".format(max_invalid_entries))
-    _waiting_for_debugger = None
-    # Sleep for a fraction of second for the print statements to get printed.
-    time.sleep(0.01)
+    else:
+        print("Exiting after {} invalid responses.".format(max_invalid_entries))
+        _waiting_for_debugger = None
+        # Sleep for a fraction of second for the print statements to get printed.
+        time.sleep(0.01)
 
 
 def _debug_exception(*exc_info, **kwargs):


### PR DESCRIPTION
Before this commit, the prompt while exiting the debugger to get user opinion on keeping the debuggable process alive was buggy.

1. Yes/No seems to be doing the same thing.
2. Displaying invalid response even after yes/y/no/n

This commit fixes this bug.

Issue: https://github.com/deshaw/pyflyby/issues/253

Author: Umair Anis
Reviewer: Sachin Gupta