### PR TITLE
Allow custom formatting options with black

### DIFF
--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -213,7 +213,8 @@ def parse_args(
         group.add_option('--black', action='store_true', default=False,
                          help=hfmt('''
                              Use black to format imports. If this option is
-                             used, all other formatting options are ignored.'''))
+                             used, all other formatting options are ignored,
+                             except width'''))
         group.add_option('--hanging-indent', type='choice', default='never',
                          choices=['never','auto','always'],
                          metavar='never|auto|always',

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -207,7 +207,7 @@ def parse_args(
                          help=hfmt('''
                              (Default) Don't align the 'from __future__ import
                              ...' statement.'''))
-        group.add_option('--width', type='int', default=79, metavar='N',
+        group.add_option('--width', type='int', default=None, metavar='N',
                          help=hfmt('''
                              Maximum line length (default: 79).'''))
         group.add_option('--black', action='store_true', default=False,

--- a/lib/python/pyflyby/_format.py
+++ b/lib/python/pyflyby/_format.py
@@ -8,7 +8,8 @@ import six
 
 
 class FormatParams(object):
-    max_line_length = 79
+    max_line_length = None
+    _max_line_lenght_default = 79
     wrap_paren = True
     indent = 4
     hanging_indent = 'never'
@@ -36,6 +37,9 @@ class FormatParams(object):
                 else:
                     raise ValueError("bad kwarg %r" % (key,))
         return self
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} {self.__dict__}>'
 
 
 def fill(tokens, sep=(", ", ""), prefix="", suffix="", newline="\n",
@@ -125,7 +129,7 @@ def pyfill(prefix, tokens, params=FormatParams()):
     :rtype:
       ``str``
     """
-    N = params.max_line_length
+    N = params.max_line_length or params._max_line_lenght_default
     if params.wrap_paren:
         # Check how we will break up the tokens.
         len_full = sum(len(tok) for tok in tokens) + 2 * (len(tokens)-1)

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -5,7 +5,6 @@
 
 
 import ast
-import subprocess
 from   collections              import namedtuple
 from   functools                import total_ordering
 
@@ -17,8 +16,8 @@ from   pyflyby._util            import (Inf, cached_attribute, cmp,
                                         longest_common_prefix)
 
 from   black                    import (find_pyproject_toml, format_str,
-                                        parse_pyproject_toml, format_str,
-                                        TargetVersion, FileMode as Mode)
+                                        parse_pyproject_toml, TargetVersion,
+                                        FileMode as Mode)
 
 
 def read_black_config():
@@ -550,7 +549,7 @@ class ImportStatement(object):
             }
             bad_target_versions = target_versions_in - set(all_target_versions)
             if bad_target_versions:
-                raise ConfigurationError(
+                raise ValueError(
                     f"Invalid target version(s) {bad_target_versions}"
                 )
             mode["target_versions"] = {

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -9,7 +9,6 @@ import subprocess
 from   collections              import namedtuple
 from   functools                import total_ordering
 
-from pyflyby import logger
 from   pyflyby._flags           import CompilerFlags
 from   pyflyby._format          import FormatParams, pyfill
 from   pyflyby._idents          import is_identifier
@@ -509,7 +508,6 @@ class ImportStatement(object):
                 formatted_code = completed_process.stdout
                 return formatted_code
             else:
-                logger.info(f"Black command failed: {black_cmd}")
                 raise ValueError(completed_process.stderr)
         except Exception:
             raise

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -9,8 +9,6 @@ import subprocess
 from   collections              import namedtuple
 from   functools                import total_ordering
 
-import black
-
 from pyflyby import logger
 from   pyflyby._flags           import CompilerFlags
 from   pyflyby._format          import FormatParams, pyfill

--- a/setup.py
+++ b/setup.py
@@ -221,8 +221,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
     ],
-    install_requires=["six", "toml", "isort", "pathlib ; python_version<'3'"],
-    python_requires=">3.0, !=3.0.*, !=3.1.*, !=3.2.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, <4",
+    install_requires=["six", "toml", "isort", "black"],
+    python_requires=">3.6, <4",
     tests_require=['pexpect>=3.3', 'pytest', 'epydoc', 'rlipython', 'requests'],
     cmdclass = {
         'test'           : PyTest,


### PR DESCRIPTION
Fixes #264 

- [x] This allows to `tidy-import` to use black with available configuration, like say `pyproject.toml`
- [x] Don't ignore width when using `black` with `tidy-import`