### PR TITLE
Fix Syntax error due to extra new lines in tidy-imports

### DIFF
--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -564,12 +564,29 @@ def sort_imports(codeblock):
 
     # Step 3: Create the output list of lines with blank lines around groups with more than one import
     output_lines = []
+
+    def next_line(index):
+        if index + 1 < len(lines):
+            return lines[index + 1]
+        else:
+            return ""
+
     for i, line in enumerate(lines):
-        if i > 0 and line_pkg_dict.get(i) != line_pkg_dict.get(i-1) and len(pkg_lines[line_pkg_dict.get(i)]) > 1:
-            output_lines.append('')
+        if (
+            i > 0
+            and line_pkg_dict.get(i) != line_pkg_dict.get(i - 1)
+            and len(pkg_lines[line_pkg_dict.get(i)]) > 1
+            and next_line(i).startswith(("import", "from"))
+        ):
+            output_lines.append("")
         output_lines.append(line)
-        if i < len(lines) - 1 and line_pkg_dict.get(i) != line_pkg_dict.get(i+1) and len(pkg_lines[line_pkg_dict.get(i)]) > 1:
-            output_lines.append('')
+        if (
+            i < len(lines) - 1
+            and line_pkg_dict.get(i) != line_pkg_dict.get(i + 1)
+            and len(pkg_lines[line_pkg_dict.get(i)]) > 1
+            and next_line(i).startswith(("import", "from"))
+        ):
+            output_lines.append("")
 
     # Step 4: Join the lines to create the output string
     sorted_output_str = '\n'.join(output_lines)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -709,8 +709,12 @@ def test_debug_filetype_with_py():
 
 
 def test_tidy_imports_sorting():
-    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
-        f.write(dedent("""
+    with tempfile.NamedTemporaryFile(suffix=".py", mode="w+") as f:
+        f.write(
+            dedent(
+                """
+            from very_very_very_long_named_package.very_long_named_module \
+                                import(small_class, very_large_named_class as small_name)
             import numpy
 
             from pkg1.mod1 import foo
@@ -736,10 +740,16 @@ def test_tidy_imports_sorting():
             baz
             baar
             sympy
-        """).lstrip())
+            small_class
+            small_name
+        """
+            ).lstrip()
+        )
         f.flush()
-        result = pipe([BIN_DIR+"/tidy-imports", f.name])
-        expected = dedent("""
+        result = pipe([BIN_DIR + "/tidy-imports", f.name])
+        expected = (
+            dedent(
+                """
             import numpy
 
             from   pkg1.mod1                import foo, foo2
@@ -748,6 +758,9 @@ def test_tidy_imports_sorting():
 
             from   pkg2                     import baar, baz
             import sympy
+            from   very_very_very_long_named_package.very_long_named_module \\
+                                            import (small_class,
+                                                    very_large_named_class as small_name)
             import yy
             import zz
 
@@ -762,7 +775,13 @@ def test_tidy_imports_sorting():
             baz
             baar
             sympy
-        """).strip().format(f=f)
+            small_class
+            small_name
+        """
+            )
+            .strip()
+            .format(f=f)
+        )
         assert result == expected
 
 

--- a/tests/test_imports2s.py
+++ b/tests/test_imports2s.py
@@ -885,21 +885,36 @@ def test_transform_imports_1():
 
 
 def test_canonicalize_imports_1():
-    input = PythonBlock(dedent('''
+    input = PythonBlock(
+        dedent(
+            """
+        from very_very_very_long_named_package.very_long_named_module \\
+                                import(small_class, very_large_named_class as small_name)
         from m import x
         from m import x as X
         import m.x
         print(m.x, m.xx)
-    ''').lstrip(), filename="/foo/test_transform_imports_1.py")
-    db = ImportDB("""
+    """
+        ).lstrip(),
+        filename="/foo/test_transform_imports_1.py",
+    )
+    db = ImportDB(
+        """
         __canonical_imports__ = {"m.x": "m.y.z"}
-    """)
+    """
+    )
     output = canonicalize_imports(input, db=db)
-    expected = PythonBlock(dedent('''
+    expected = PythonBlock(
+        dedent("""
         import m.y.z
-        from m.y import z as X, z as x
+        from m.y                                                      import (z as X,
+                                                                              z as x)
+        from very_very_very_long_named_package.very_long_named_module import (small_class,
+                                                                              very_large_named_class as small_name)
         print(m.y.z, m.xx)
-    ''').lstrip(), filename="/foo/test_transform_imports_1.py")
+        """).lstrip(),
+        filename="/foo/test_transform_imports_1.py",
+    )
     assert output == expected
 
 


### PR DESCRIPTION
This should fix #272, but I have issues running tests locally.