### PR TITLE
Test on more recent Python versions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         include:
           - os: macos-latest
             python-version: "3.10"
@@ -31,7 +32,7 @@ jobs:
     - name: Install and update Python dependencies on Python 3
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade "pexpect>=3.3" 'pytest<7' rlipython 'ipykernel>=5.4.3' requests jupyter flaky 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3' ipython 'coverage<6.3' pytest-json-report
+        python -m pip install --upgrade "pexpect>=3.3" 'pytest<=8' rlipython 'ipykernel>=5.4.3' requests jupyter flaky 'notebook<6.1' wheel 'jupyter_console>=6.2' pytest-cov ipython coverage pytest-json-report
         pip install -e .
     - name: test release build
       run: |
@@ -61,7 +62,7 @@ jobs:
           ./report-*.json
     - uses: codecov/codecov-action@v2
     - name: Build docs
-      if: ${{ matrix.python-version == '3.10'}}
+      if: ${{ matrix.python-version == '3.11'}}
       run: |
         pip install sphinx sphinx_rtd_theme sphinx-autodoc-typehints
         cd doc

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -260,7 +260,10 @@ def _test_parse_string_literal(text, flags):
     body = module_node.body
     if not _is_ast_str_or_byte(body):
         return None
-    return body.s
+    if sys.version_info < (3 ,9):
+        return body.s
+    else:
+        return body.value
 
 
 AstNodeContext = namedtuple("AstNodeContext", "parent field index")

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -3854,7 +3854,7 @@ def test_debug_tab_completion_db_1(frontend):
     """, frontend=frontend)
 
 
-@retry
+@pytest.mark.xfail(IPython.version_info >= (8, 14), reason='not working on tab completion since https://github.com/ipython/ipython/pull/13889')
 def test_debug_tab_completion_module_1(frontend, tmp):
     # Verify that tab completion on module names works.
     writetext(tmp.dir/"thornton60097181.py", """
@@ -3900,7 +3900,7 @@ def test_debug_tab_completion_multiple_1(frontend, tmp):
     """, PYTHONPATH=tmp.dir, frontend=frontend)
 
 
-@retry
+@pytest.mark.xfail(IPython.version_info >= (8, 14), reason='not working on tab completion since https://github.com/ipython/ipython/pull/13889')
 def test_debug_postmortem_tab_completion_1(frontend):
     # Verify that tab completion in %debug postmortem mode works.
     ipython("""
@@ -3922,7 +3922,7 @@ def test_debug_postmortem_tab_completion_1(frontend):
         ipdb> q
     """, frontend=frontend)
 
-
+@pytest.mark.xfail(IPython.version_info >= (8, 14), reason='not working on tab completion since https://github.com/ipython/ipython/pull/13889')
 def test_debug_namespace_1_py3(frontend):
     # Verify that autoimporting and tab completion happen in the local
     # namespace.
@@ -3953,7 +3953,6 @@ def test_debug_namespace_1_py3(frontend):
     """, frontend=frontend)
 
 
-@retry
 def test_debug_second_1(frontend):
     # Verify that a second postmortem debug of the same function behaves as
     # expected.


### PR DESCRIPTION


This does a number of things:

  - raise pytest pinning to version 8,
  - test CI on 3.11
  - update deprecated formatargspec to use signature
  - update various ast node to use Constant, and .value instead of .s

We also mark a few test as xfail – as they have been failing for a
while, but IPython was indirectly pinned via prompt_toolkit).

And we also start to add a couple of compatibility to bytecode for
Python 3.12.