### PR TITLE
Skip hanging test. 

### DIFF
--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -3311,12 +3311,9 @@ def test_ipython_notebook_basic_1():
             Out[2]: 77
             """, args=['console'], kernel=kernel)
 
-@pytest.mark.xfail(
-    sys.version_info[0] == 3,
-    reason="Need newer version of jupyter_console > 6.4.1 maybe ? Coroutine not awaited",
-    strict=False,
+@pytest.mark.skip(
+    reason="Always hang, need to investigate",
 )
-@retry
 def test_ipython_notebook_1():
     with IPythonNotebookCtx() as kernel:
         # 1. Verify that the auto importer isn't enabled yet.


### PR DESCRIPTION
This will help not having the test suite hang for 40 minutes each times. 