### PR TITLE
Reify six.string_types to str.

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -1489,7 +1489,7 @@ def find_missing_imports(arg, namespaces):
       ``list`` of ``DottedIdentifier``
     """
     namespaces = ScopeStack(namespaces)
-    if isinstance(arg, (DottedIdentifier, six.string_types)):
+    if isinstance(arg, (DottedIdentifier, str)):
         try:
             arg = DottedIdentifier(arg)
         except BadDottedIdentifierError:
@@ -1897,7 +1897,7 @@ def auto_eval(arg, filename=None, mode=None,
     """
     if isinstance(flags, int):
         assert isinstance(flags, CompilerFlags)
-    if isinstance(arg, (six.string_types, Filename, FileText, PythonBlock)):
+    if isinstance(arg, (str, Filename, FileText, PythonBlock)):
         block = PythonBlock(arg, filename=filename, flags=flags,
                             auto_flags=auto_flags)
         flags = block.flags

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -3,7 +3,7 @@
 # License: MIT http://opensource.org/licenses/MIT
 
 
-
+import builtins
 from   contextlib               import contextmanager
 import errno
 from   functools                import wraps
@@ -13,9 +13,6 @@ import signal
 import sys
 import time
 from   types                    import CodeType, FrameType, TracebackType
-
-import six
-from   six.moves                import builtins
 
 from   collections.abc          import Callable
 
@@ -349,7 +346,8 @@ def _debug_code(arg, globals=None, locals=None, auto_import=True, tty="/dev/tty"
         print("Entering debugger.  Use 'n' to step, 'c' to run, 'q' to stop.")
         print("")
         from ._parse import PythonStatement, PythonBlock, FileText
-        if isinstance(arg, (six.string_types, PythonStatement, PythonBlock, FileText)):
+
+        if isinstance(arg, (str, PythonStatement, PythonBlock, FileText)):
             # Compile the block so that we can get the right compile mode.
             arg = PythonBlock(arg)
             # TODO: enter text into linecache
@@ -502,8 +500,9 @@ def debugger(*args, **kwargs):
             # TODO: capture globals/locals when relevant.
             wait_for_debugger_to_attach(arg)
             return
-    if isinstance(arg, (six.string_types, PythonStatement, PythonBlock, FileText,
-                        CodeType, Callable)):
+    if isinstance(
+        arg, (str, PythonStatement, PythonBlock, FileText, CodeType, Callable)
+    ):
         _debug_code(arg, globals=globals, locals=locals, tty=tty)
         on_continue()
         return
@@ -1013,12 +1012,12 @@ def inject(pid, statements, wait=True, show_gdb_output=False):
     """
     import subprocess
     os.kill(pid, 0) # raises OSError "No such process" unless pid exists
-    if isinstance(statements, six.string_types):
+    if isinstance(statements, str):
         statements = (statements,)
     else:
         statements = tuple(statements)
     for statement in statements:
-        if not isinstance(statement, six.string_types):
+        if not isinstance(statement, str):
             raise TypeError(
                 "Expected iterable of strings, not %r" % (type(statement),))
     # Based on

--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -8,10 +8,7 @@ from   functools                import total_ordering
 import io
 import os
 import re
-import six
 import sys
-
-from   six                      import string_types
 
 from   pyflyby._util            import cached_attribute, cmp, memoize
 
@@ -34,13 +31,13 @@ class Filename(object):
     def __new__(cls, arg):
         if isinstance(arg, cls):
             return arg
-        if isinstance(arg, six.string_types):
+        if isinstance(arg, str):
             return cls._from_filename(arg)
         raise TypeError
 
     @classmethod
     def _from_filename(cls, filename):
-        if not isinstance(filename, six.string_types):
+        if not isinstance(filename, str):
             raise TypeError
         filename = str(filename)
         if not filename:
@@ -372,7 +369,7 @@ class FileText(object):
             return cls(read_file(arg), filename=filename, startpos=startpos)
         elif hasattr(arg, "__text__"):
             return FileText(arg.__text__(), filename=filename, startpos=startpos)
-        elif isinstance(arg, six.string_types):
+        elif isinstance(arg, str):
             self = object.__new__(cls)
             self.joined = arg
         else:
@@ -389,7 +386,7 @@ class FileText(object):
     def _from_lines(cls, lines, filename, startpos):
         assert type(lines) is tuple
         assert len(lines) > 0
-        assert isinstance(lines[0], string_types)
+        assert isinstance(lines[0], str)
         assert not lines[-1].endswith("\n")
         self = object.__new__(cls)
         self.lines    = lines

--- a/lib/python/pyflyby/_idents.py
+++ b/lib/python/pyflyby/_idents.py
@@ -7,7 +7,6 @@
 from   functools                import total_ordering
 from   keyword                  import kwlist
 import re
-import six
 
 from   pyflyby._util            import cached_attribute, cmp
 
@@ -111,7 +110,7 @@ def is_identifier(s, dotted=False, prefix=False):
     :rtype:
       ``bool``
     """
-    if not isinstance(s, six.string_types):
+    if not isinstance(s, str):
         raise TypeError("is_identifier(): expected a string; got a %s"
                         % (type(s).__name__,))
     if prefix:
@@ -144,7 +143,7 @@ class DottedIdentifier(object):
     def __new__(cls, arg, scope_info=None):
         if isinstance(arg, cls):
             return arg
-        if isinstance(arg, six.string_types):
+        if isinstance(arg, str):
             return cls._from_name(arg, scope_info)
         if isinstance(arg, (tuple, list)):
             return cls._from_name(".".join(arg), scope_info)

--- a/lib/python/pyflyby/_importdb.py
+++ b/lib/python/pyflyby/_importdb.py
@@ -504,27 +504,27 @@ class ImportDB(object):
 
     @classmethod
     def _parse_import_set(cls, arg):
-        if isinstance(arg, six.string_types):
+        if isinstance(arg, str):
             arg = [arg]
         if not isinstance(arg, (tuple, list)):
             raise ValueError("Expected a list, not a %s" % (type(arg).__name__,))
         for item in arg:
-            if not isinstance(item, six.string_types):
+            if not isinstance(item, str):
                 raise ValueError(
                     "Expected a list of str, not %s" % (type(item).__name__,))
         return ImportSet(arg)
 
     @classmethod
     def _parse_import_map(cls, arg):
-        if isinstance(arg, six.string_types):
+        if isinstance(arg, str):
             arg = [arg]
         if not isinstance(arg, dict):
             raise ValueError("Expected a dict, not a %s" % (type(arg).__name__,))
         for k, v in arg.items():
-            if not isinstance(k, six.string_types):
+            if not isinstance(k, str):
                 raise ValueError(
                     "Expected a dict of str, not %s" % (type(k).__name__,))
-            if not isinstance(v, six.string_types):
+            if not isinstance(v, str):
                 raise ValueError(
                     "Expected a dict of str, not %s" % (type(v).__name__,))
         return ImportMap(arg)

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -1106,7 +1106,7 @@ def _list_members_for_completion(obj, ip):
                 pass
         else:
             words = dir(obj)
-    return [w for w in words if isinstance(w, six.string_types)]
+    return [w for w in words if isinstance(w, str)]
 
 
 def _auto_import_in_pdb_frame(pdb_instance, arg):

--- a/lib/python/pyflyby/_livepatch.py
+++ b/lib/python/pyflyby/_livepatch.py
@@ -564,7 +564,8 @@ def _format_age(t):
 def _interpret_module(arg):
     def mod_fn(module):
         return getattr(module, "__file__", None)
-    if isinstance(arg, six.string_types):
+
+    if isinstance(arg, str):
         try:
             return sys.modules[arg]
         except KeyError:

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -19,7 +19,6 @@ import re
 import readline
 import requests
 from   shutil                   import rmtree
-import six
 from   six                      import BytesIO
 from   subprocess               import check_call
 import sys
@@ -514,7 +513,7 @@ def _build_pythonpath(PYTHONPATH):
     pypath = [os.path.dirname(os.path.dirname(pyflyby.__file__))]
     if sys.version_info < (3, 9):
         pypath += _extra_readline_pythonpath_dirs()
-    if isinstance(PYTHONPATH, (Filename, six.string_types)):
+    if isinstance(PYTHONPATH, (Filename, str)):
         PYTHONPATH = [PYTHONPATH]
     PYTHONPATH = [str(Filename(d)) for d in PYTHONPATH]
     pypath += PYTHONPATH
@@ -583,7 +582,7 @@ def _build_ipython_cmd(ipython_dir, prog="ipython", args=[], autocall=False, fro
     else:
         # Get the program from the python that is running.
         cmd += [os.path.join(os.path.dirname(sys.executable), prog)]
-    if isinstance(args, six.string_types):
+    if isinstance(args, str):
         args = [args]
     if args and not args[0].startswith("-"):
         app = args[0]
@@ -1043,7 +1042,7 @@ def ipython(template, **kwargs):
     template = dedent(template).strip()
     input, expected = parse_template(template, clear_tab_completions=_IPYTHON_VERSION>=(7,))
     args = kwargs.pop("args", ())
-    if isinstance(args, six.string_types):
+    if isinstance(args, str):
         args = [args]
     args = list(args)
     if args and not args[0].startswith("-"):

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -8,14 +8,11 @@
 import os
 import pytest
 from   shutil                   import rmtree
-import six
 import subprocess
 import sys
 import tempfile
 from   tempfile                 import NamedTemporaryFile, mkdtemp
 from   textwrap                 import dedent
-
-from   six                      import string_types
 
 import pyflyby
 from   pyflyby._file            import Filename
@@ -30,7 +27,7 @@ PYFLYBY_PATH = PYFLYBY_HOME / "etc/pyflyby"
 def flatten(args):
     result = []
     for arg in args:
-        if isinstance(arg, six.string_types):
+        if isinstance(arg, str):
             result.append(arg)
         else:
             try:
@@ -100,7 +97,7 @@ def _build_pythonpath(PYTHONPATH):
       ``str``
     """
     pypath = [os.path.dirname(os.path.dirname(pyflyby.__file__))]
-    if isinstance(PYTHONPATH, (Filename,) + string_types):
+    if isinstance(PYTHONPATH, (Filename, str)):
         PYTHONPATH = [PYTHONPATH]
     PYTHONPATH = [str(Filename(d)) for d in PYTHONPATH]
     pypath += PYTHONPATH


### PR DESCRIPTION
We are Python3 only now, this is always str.

This should slowly help to remove six, that should be unnecessary.