### PR TITLE
Test effect of un-pinning ipykernel.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install and update Python dependencies on Python 3
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade "pexpect>=3.3" 'pytest<7' rlipython ipykernel==5.4.3 requests jupyter flaky 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3' ipython 'coverage<6.3' pytest-json-report
+        python -m pip install --upgrade "pexpect>=3.3" 'pytest<7' rlipython 'ipykernel>=5.4.3' requests jupyter flaky 'notebook<6.1' 'prompt_toolkit<3.0.15' wheel 'jupyter_console>=6.2' 'pytest-cov<3' ipython 'coverage<6.3' pytest-json-report
         pip install -e .
     - name: test release build
       run: |


### PR DESCRIPTION
This is extracted from another PR that tries to update CI to test on Python 3.11 and 3.12, but with all the changes it is hard to detect the effects of one change versus another.