### PR TITLE
MAINT: Replace custom implementation by stdlib where appropriate

### DIFF
--- a/lib/python/pyflyby/_importclns.py
+++ b/lib/python/pyflyby/_importclns.py
@@ -215,8 +215,8 @@ class ImportSet(object):
         """
         :return:
           (mapping from name to __future__ imports,
-           mapping from name to non-'from' imports,
-           mapping from name to 'from' imports)
+          mapping from name to non-'from' imports,
+          mapping from name to 'from' imports)
         """
         ftr_imports = defaultdict(set)
         pkg_imports = defaultdict(set)

--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -303,7 +303,7 @@ class ModuleHandle(object):
         Enumerate the importable submodules of this module.
 
           >>> ModuleHandle("email").submodules      # doctest:+ELLIPSIS
-          (..., 'email.encoders', ..., 'email.mime', ...)
+          (..., ModuleHandle('email.encoders'), ..., ModuleHandle('email.mime'), ...)
 
         :rtype:
           ``tuple`` of `ModuleHandle` s


### PR DESCRIPTION
Mostly this make static typing tools aware of what those decorators do.