### PR TITLE
Make isort import lazy + Typing issues

### DIFF
--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -920,6 +920,8 @@ class PythonBlock(object):
 
     """
 
+    text: FileText
+
     def __new__(cls, arg, filename=None, startpos=None, flags=None,
                 auto_flags=None):
         if isinstance(arg, PythonStatement):


### PR DESCRIPTION
`output` was both sometime a method and sometime a attribute. Rename the attribute to `_output`.

Closes #274