### PR TITLE
Misc updates and types annotations + unused parameter deprecation

### DIFF
--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -4,13 +4,13 @@
 
 
 
-from   functools                import total_ordering
+from   functools                import total_ordering, cached_property
 import io
 import os
 import re
 import sys
 
-from   pyflyby._util            import cached_attribute, cmp, memoize
+from   pyflyby._util            import cmp, memoize
 
 
 class UnsafeFilenameError(ValueError):
@@ -85,7 +85,7 @@ class Filename(object):
             return NotImplemented
         return cmp(self._filename, o._filename)
 
-    @cached_attribute
+    @cached_property
     def ext(self):
         """
         Returns the extension of this filename, including the dot.
@@ -99,15 +99,15 @@ class Filename(object):
             return None
         return dot + rhs
 
-    @cached_attribute
+    @cached_property
     def base(self):
         return os.path.basename(self._filename)
 
-    @cached_attribute
+    @cached_property
     def dir(self):
         return type(self)(os.path.dirname(self._filename))
 
-    @cached_attribute
+    @cached_property
     def real(self):
         return type(self)(os.path.realpath(self._filename))
 
@@ -394,7 +394,7 @@ class FileText:
         self.startpos = startpos
         return self
 
-    @cached_attribute
+    @cached_property
     def lines(self):
         r"""
         Lines that have been split by newline.
@@ -414,7 +414,7 @@ class FileText:
         # (or requires extra work to process if we use splitlines(True)).
         return tuple(self.joined.split('\n'))
 
-    @cached_attribute
+    @cached_property
     def joined(self): # used if only initialized with 'lines'
         return '\n'.join(self.lines)
 
@@ -441,7 +441,7 @@ class FileText:
             result.startpos = startpos
             return result
 
-    @cached_attribute
+    @cached_property
     def endpos(self):
         """
         The position after the last character in the text.

--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -28,6 +28,8 @@ class Filename(object):
       Filename('/etc/passwd')
 
     """
+    _filename: str
+
     def __new__(cls, arg):
         if isinstance(arg, cls):
             return arg
@@ -337,6 +339,8 @@ class FileText:
     """
     Represents a contiguous sequence of lines from a file.
     """
+
+    filename: Filename
 
     def __new__(cls, arg, filename=None, startpos=None):
         """

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -200,12 +200,10 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
                     # insert in the middle.
                     self.blocks[:1] = (
                         [SourceToSourceTransformation(
-                            PythonBlock.concatenate(statements[:idx],
-                                                    assume_contiguous=True))] +
+                            PythonBlock.concatenate(statements[:idx]))] +
                         blocks +
                         [SourceToSourceTransformation(
-                            PythonBlock.concatenate(statements[idx:],
-                                                    assume_contiguous=True))])
+                            PythonBlock.concatenate(statements[idx:]))])
                 break
         else:
             # First block is entirely comments, so just insert after it.

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -14,6 +14,7 @@ import sys
 from   textwrap                 import dedent
 import types
 from   typing                   import Optional
+import warnings
 
 from   pyflyby._file            import FilePos, FileText, Filename
 from   pyflyby._flags           import CompilerFlags
@@ -22,6 +23,8 @@ from   pyflyby._util            import cached_attribute, cmp
 
 
 from ast import TypeIgnore, AsyncFunctionDef
+
+_sentinel = object()
 
 
 def _is_comment_or_blank(line):
@@ -1005,17 +1008,21 @@ class PythonBlock:
         return self
 
     @classmethod
-    def concatenate(cls, blocks, assume_contiguous=False):
+    def concatenate(cls, blocks, assume_contiguous=_sentinel):
         """
         Concatenate a bunch of blocks into one block.
 
         :type blocks:
           sequence of `PythonBlock` s and/or `PythonStatement` s
         :param assume_contiguous:
+          Deprecated, always True
           Whether to assume, without checking, that the input blocks were
           originally all contiguous.  This must be set to True to indicate the
           caller understands the assumption; False is not implemented.
         """
+        if assume_contiguous is not _sentinel:
+            warnings.warn('`assume_continuous` is deprecated and considered always `True`')
+            assume_contiguous = True
         if not assume_contiguous:
             raise NotImplementedError
         blocks = [PythonBlock(b) for b in blocks]

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -1267,7 +1267,7 @@ class PythonBlock:
         cls = type(self)
         for pred, stmts in groupby(self.statements, predicate):
             blocks = [s.block for s in stmts]
-            yield pred, cls.concatenate(blocks, assume_contiguous=True)
+            yield pred, cls.concatenate(blocks)
 
     def string_literals(self):
         r"""


### PR DESCRIPTION
This does a few things:
   - Rename cached property to avoid static typing error, despite the aliasing, some tools still don't like it
   - Add is_comment and is_blank for PythonStatement this will be useful for import sorting.
   - deprecate unused `assume_contiguous` kwarg
   - some Filetext typing information to decrease static typing IDE noise.






