### PR TITLE
Make shebang portable

### DIFF
--- a/bin/autopython
+++ b/bin/autopython
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 # pyflyby/autopython
 

--- a/bin/create-imports
+++ b/bin/create-imports
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 # pyflyby/create-imports
 

--- a/libexec/pyflyby/colordiff
+++ b/libexec/pyflyby/colordiff
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 # License for THIS FILE ONLY: CC0 Public Domain Dedication
 # http://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
Some Linux distribution, like NixOS, does not have `/bin/bash`.