### PR TITLE
MAINT: be stricter on str/Filename

### DIFF
--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -4,10 +4,10 @@
 
 
 
+from   builtins                 import input
 import optparse
 import os
 import signal
-from   builtins                 import input
 import sys
 from   textwrap                 import dedent
 import traceback
@@ -285,7 +285,8 @@ def parse_args(
 def _default_on_error(filename):
     raise SystemExit("bad filename %s" % (filename,))
 
-def filename_args(args, on_error=_default_on_error):
+
+def filename_args(args: List[str], on_error=_default_on_error):
     """
     Return list of filenames given command-line arguments.
 
@@ -293,7 +294,9 @@ def filename_args(args, on_error=_default_on_error):
       ``list`` of `Filename`
     """
     if args:
-        return expand_py_files_from_args(args, on_error)
+        for a in args:
+            assert isinstance(a, str)
+        return expand_py_files_from_args([Filename(f) for f in args], on_error)
     elif not os.isatty(0):
         return [Filename.STDIN]
     else:

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -23,9 +23,12 @@ import types
 from   typing                   import Any, List, Optional, Tuple, Union, cast
 import warnings
 
+
 _sentinel = object()
 
 if sys.version_info < (3, 10):
+
+    NoneType = type(None)
 
     class MatchAs:
         name: str
@@ -36,6 +39,7 @@ if sys.version_info < (3, 10):
         patterns: List[MatchAs]
 
 else:
+    from types import NoneType
     from ast import MatchAs, MatchMapping
 
 
@@ -963,6 +967,9 @@ class PythonBlock:
         :rtype:
           `PythonBlock`
         """
+        if isinstance(filename, str):
+            filename = Filename(filename)
+        assert isinstance(filename, (Filename, NoneType)), filename
         text = FileText(text, filename=filename, startpos=startpos)
         self = object.__new__(cls)
         self.text = text

--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -343,11 +343,11 @@ $ py                                       IPython shell
 # TODO: add --profile, --runsnake
 
 import ast
+import builtins
 from   contextlib               import contextmanager
 import inspect
 import os
 import re
-import builtins
 import sys
 import types
 from   types                    import FunctionType, MethodType
@@ -1303,7 +1303,7 @@ def _has_python_shebang(filename):
     Note that this test is only needed for scripts found via which(), since
     otherwise the shebang is not necessary.
     """
-    filename = Filename(filename)
+    assert isinstance(filename, Filename)
     with open(str(filename), 'rb') as f:
         line = f.readline(1024)
         return line.startswith(b"#!") and b"python" in line

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -17,9 +17,9 @@ from   pyflyby                  import (Filename, ImportDB, auto_eval,
                                         auto_import, find_missing_imports)
 from   pyflyby._autoimp         import (LoadSymbolError, load_symbol,
                                         scan_for_import_issues)
+from   pyflyby._flags           import CompilerFlags
 from   pyflyby._idents          import DottedIdentifier
 from   pyflyby._importstmt      import Import
-from   pyflyby._flags           import CompilerFlags
 from   pyflyby._util            import CwdCtx
 
 
@@ -46,7 +46,7 @@ def tpp(request):
 
 def writetext(filename, text, mode='w'):
     text = dedent(text)
-    filename = Filename(filename)
+    assert isinstance(filename, Filename)
     with open(str(filename), mode) as f:
         f.write(text)
     return filename
@@ -2200,4 +2200,20 @@ def test_unsafe_filename_warning(tpp, capsys):
     expected = dedent("""
         [PYFLYBY] import pyflyby
     """).lstrip()
+    assert out.startswith(expected)
+
+
+def test_unsafe_filename_warning_II(tpp, capsys):
+    filepath = os.path.join(tpp._filename, "foo#bar")
+    os.mkdir(filepath)
+    filepath = os.path.join(filepath, "qux#baz")
+    os.mkdir(filepath)
+    with CwdCtx(filepath):
+        auto_import("pyflyby", [{}])
+    out, _ = capsys.readouterr()
+    expected = dedent(
+        """
+        [PYFLYBY] import pyflyby
+    """
+    ).lstrip()
     assert out.startswith(expected)

--- a/tests/test_livepatch.py
+++ b/tests/test_livepatch.py
@@ -35,7 +35,7 @@ def tpp(request):
 
 def writetext(filename, text, mode='w'):
     text = dedent(text)
-    filename = Filename(filename)
+    assert isinstance(filename, Filename)
     with open(str(filename), mode) as f:
         f.write(text)
     return filename

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -14,10 +14,11 @@ import tempfile
 from   tempfile                 import NamedTemporaryFile, mkdtemp
 from   textwrap                 import dedent
 
-import pyflyby
 from   pyflyby._file            import Filename
 from   pyflyby._util            import cached_attribute
 
+
+from   tests.test_interactive   import _build_pythonpath
 
 PYFLYBY_HOME = Filename(__file__).real.dir.dir
 BIN_DIR = PYFLYBY_HOME / "bin"
@@ -89,28 +90,15 @@ class _TmpFixture(object):
         return Filename(d).real
 
 
-def _build_pythonpath(PYTHONPATH):
-    """
-    Build PYTHONPATH value to use.
-
-    :rtype:
-      ``str``
-    """
-    pypath = [os.path.dirname(os.path.dirname(pyflyby.__file__))]
-    if isinstance(PYTHONPATH, (Filename, str)):
-        PYTHONPATH = [PYTHONPATH]
-    PYTHONPATH = [str(Filename(d)) for d in PYTHONPATH]
-    pypath += PYTHONPATH
-    pypath += os.environ["PYTHONPATH"].split(":")
-    return ":".join(pypath)
-
 
 def _py_internal_1(args, stdin="",
                    PYTHONPATH=[],
                    PYFLYBY_PATH=PYFLYBY_PATH):
     env = dict(os.environ)
-    env["PYFLYBY_PATH" ] = str(Filename(PYFLYBY_PATH))
-    env["PYTHONPATH"   ] = _build_pythonpath(PYTHONPATH)
+    if isinstance(PYFLYBY_PATH, str):
+        PYFLYBY_PATH = Filename(PYFLYBY_PATH)
+    env["PYFLYBY_PATH"] = str(PYFLYBY_PATH)
+    env["PYTHONPATH"] = _build_pythonpath(PYTHONPATH)
     env["PYTHONSTARTUP"] = ""
     prog = str(BIN_DIR/"py")
     return pipe((prog,) + args, stdin=stdin, env=env)
@@ -127,7 +115,7 @@ def py(*args, **kwargs):
 
 def writetext(filename, text, mode='w'):
     text = dedent(text)
-    filename = Filename(filename)
+    assert isinstance(filename, Filename)
     with open(str(filename), mode) as f:
         f.write(text)
     return filename


### PR DESCRIPTION
There are a bit too many places where there is a str/Filename Union. This make it hard to track issues like #346.

Thus we do some refactor and enforce Filename in many places in order to make reasonning on the code easier.