### PR TITLE
Turn off some deprecated features

### DIFF
--- a/lib/python/pyflyby/_importdb.py
+++ b/lib/python/pyflyby/_importdb.py
@@ -28,7 +28,7 @@ if sys.version_info <= (3, 12):
 else:
     from typing import Self
 
-SUPPORT_DEPRECATED_BEHAVIOR = True
+SUPPORT_DEPRECATED_BEHAVIOR = False
 
 @memoize
 def _find_etc_dirs():


### PR DESCRIPTION
This has ben properly deprecated. Let's turn the codepath off for now, and see in a few release if we can actually remove

See #353