### PR TITLE
Try to detect non-global unused imports.

### DIFF
--- a/lib/python/pyflyby/_importdb.py
+++ b/lib/python/pyflyby/_importdb.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2011, 2012, 2013, 2014, 2015 Karl Chen.
 # License: MIT http://opensource.org/licenses/MIT
 
+from __future__ import annotations
+
 
 
 from   collections              import defaultdict
@@ -417,7 +419,7 @@ class ImportDB:
         return result
 
     @classmethod
-    def interpret_arg(cls, arg, target_filename):
+    def interpret_arg(cls, arg, target_filename) -> ImportDB:
         if arg is None:
             return cls.get_default(target_filename)
         else:

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -13,12 +13,12 @@ from   pyflyby._parse           import PythonBlock
 from   pyflyby._util            import ImportPathCtx, Inf, NullCtx, memoize
 import re
 
-from typing import Union
+from typing import Union, Optional, Literal
 
 from textwrap import indent
 
 
-class SourceToSourceTransformationBase(object):
+class SourceToSourceTransformationBase:
 
     input: PythonBlock
 
@@ -121,7 +121,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         result = [block.pretty_print(params=params) for block in self.blocks]
         return FileText.concatenate(result)
 
-    def find_import_block_by_lineno(self, lineno):
+    def find_import_block_by_lineno(self, lineno: int):
         """
         Find the import block containing the given line number.
 
@@ -312,11 +312,11 @@ def ImportPathForRelativeImportsCtx(codeblock):
 
 
 def fix_unused_and_missing_imports(
-    codeblock: Union[PythonBlock, str],
-    add_missing=True,
-    remove_unused="AUTOMATIC",
-    add_mandatory=True,
-    db=None,
+    codeblock: Union[PythonBlock, str, Filename],
+    add_missing: bool = True,
+    remove_unused: Union[Literal["AUTOMATIC"], bool] = "AUTOMATIC",
+    add_mandatory: bool = True,
+    db: Optional[ImportDB] = None,
     params=None,
 ) -> PythonBlock:
     r"""
@@ -345,6 +345,7 @@ def fix_unused_and_missing_imports(
     :rtype:
       `PythonBlock`
     """
+    _codeblock: PythonBlock
     if isinstance(codeblock, Filename):
         _codeblock = PythonBlock(codeblock)
     if not isinstance(codeblock, PythonBlock):
@@ -393,7 +394,7 @@ def fix_unused_and_missing_imports(
                 logger.error(
                     "%s: couldn't remove import %r", filename, imp,)
             except LineNumberNotFoundError as e:
-                logger.error(
+                logger.debug(
                     "%s: unused import %r on line %d not global",
                     filename, str(imp), e.args[0])
             else:


### PR DESCRIPTION
We do so by tracking the imports on exist of each scopestack; and on exist, if there is an import that has not been checked; we mark it as unused.

This seem to have side effects as the SourceToSource transformer is aware it cannot remove non-global imports and emit a error message.

Note that this also affects conditional imports:

```
if sys.version_info > X,y:
    from foo import bar
else:
    from foo.new import bar
```

The first import will be marked as unused as shoadowed by the second one (pyflyby does not understand the if/else).

This also does some refactor and type anotations while I am at it.