### PR TITLE
Fix lazy loading of variables

### DIFF
--- a/lib/python/pyflyby/_dynimp.py
+++ b/lib/python/pyflyby/_dynimp.py
@@ -111,7 +111,7 @@ def _add_import(ip, names: str, code: str) -> None:
     private version of add_import
     """
     assert ip is not None
-    module = PYFLYBY_LAZY_LOAD_PREFIX.split(" ")[1]
+    module = PYFLYBY_LAZY_LOAD_PREFIX.split()[1]
     mang = module + names.replace(",", "_").replace(" ", "_")
     a: FrozenSet[Import] = ImportSet(f"from {mang} import {names}")._importset
     b: FrozenSet[Import] = ip._auto_importer.db.known_imports._importset

--- a/lib/python/pyflyby/_dynimp.py
+++ b/lib/python/pyflyby/_dynimp.py
@@ -111,8 +111,9 @@ def _add_import(ip, names: str, code: str) -> None:
     private version of add_import
     """
     assert ip is not None
-    mang = PYFLYBY_LAZY_LOAD_PREFIX + names.replace(",", "_").replace(" ", "_")
-    a: FrozenSet[Import] = ImportSet(f"{mang} import {names}")._importset
+    module = PYFLYBY_LAZY_LOAD_PREFIX.split(" ")[1]
+    mang = module + names.replace(",", "_").replace(" ", "_")
+    a: FrozenSet[Import] = ImportSet(f"from {mang} import {names}")._importset
     b: FrozenSet[Import] = ip._auto_importer.db.known_imports._importset
     s_import: FrozenSet[Import] = a | b
 


### PR DESCRIPTION
This PR fixes lazy imports which broke because the `mang` variable started with `from` instead of the module name causing the imports to not be resolved by the `module_dict`