### PR TITLE
Enhance saveframe to allow saving frames even when no exception is raised

### DIFF
--- a/bin/saveframe
+++ b/bin/saveframe
@@ -288,7 +288,8 @@ def main():
         # Save the frames and metadata info to the file.
         _save_frames_and_exception_info_to_file(
             filename=filename, frames=frames, variables=variables,
-            exclude_variables=exclude_variables, exception_obj=err)
+            exclude_variables=exclude_variables,
+            exception_obj_or_current_frame=err)
     else:
         raise SystemExit(
             f"Error: No exception is raised by the program: {command_string!a}")

--- a/lib/python/pyflyby/_saveframe.py
+++ b/lib/python/pyflyby/_saveframe.py
@@ -481,8 +481,30 @@ def _get_all_frames_from_exception_obj(exception_obj):
     return all_frames
 
 
+def _get_all_frames_from_current_frame(current_frame):
+    """
+    Get all frame objects starting from the current frame up the call stack.
+
+    :param current_frame:
+      The current frame in the debugger.
+    :return
+      A list of all frame objects in bottom-to-top order, with the bottom frame
+      (current frame) at index 0.
+    """
+    all_frames = []
+    while current_frame:
+        func_name = current_frame.f_code.co_name
+        # We've reached the python internal frames. Break the loop.
+        if func_name == '<module>':
+            break
+        all_frames.append(current_frame)
+        current_frame = current_frame.f_back
+    return all_frames
+
+
 def _save_frames_and_exception_info_to_file(
-        filename, frames, variables, exclude_variables, exception_obj):
+        filename, frames, variables, exclude_variables,
+        exception_obj_or_current_frame):
     """
     Save the frames and exception information in the file ``filename``.
 
@@ -519,6 +541,9 @@ def _save_frames_and_exception_info_to_file(
           'traceback': '(multiline traceback)
       }
 
+    NOTE: Exception info (such as 'exception_*') will not be stored if
+    ``exception_obj_or_current_frame`` is a frame instead of an exception object.
+
     :param filename:
       The file path in which to save the information.
     :param frames:
@@ -528,14 +553,23 @@ def _save_frames_and_exception_info_to_file(
       The local variables to include in each frame.
     :param exclude_variables:
       The local variables to exclude from each frame.
-    :param exception_obj:
-      The ``Exception`` raised by the user's code. This is used to extract all
-      the required info; the traceback, all the frame objects, etc.
+    :param exception_obj_or_current_frame:
+      The ``Exception`` raised by the user's code, or the current frame if the
+      user is in a debugger. This is used to extract all the required info;
+      the traceback, all the frame objects, etc.
     """
+    is_frame = False
+    if inspect.isframe(exception_obj_or_current_frame):
+        is_frame = True
     # Mapping that stores all the information to save.
     frames_and_exception_info = {}
-    # Get the list of frame objects from the exception object.
-    all_frames = _get_all_frames_from_exception_obj(exception_obj)
+    if is_frame:
+        all_frames = _get_all_frames_from_current_frame(
+            exception_obj_or_current_frame)
+    else:
+        # Get the list of frame objects from the exception object.
+        all_frames = _get_all_frames_from_exception_obj(
+            exception_obj_or_current_frame)
     # Take out the frame objects we want to save as per 'frames'.
     frames_to_save = _get_frames_to_save(frames, all_frames)
     _SAVEFRAME_LOGGER.info(
@@ -549,8 +583,10 @@ def _save_frames_and_exception_info_to_file(
         frames_and_exception_info[frame_idx]['variables'] = (
             _get_frame_local_variables_data(frame_obj, variables, exclude_variables))
 
-    _SAVEFRAME_LOGGER.info("Getting exception metadata info.")
-    frames_and_exception_info.update(_get_exception_info(exception_obj).__dict__)
+    if not is_frame:
+        _SAVEFRAME_LOGGER.info("Getting exception metadata info.")
+        frames_and_exception_info.update(_get_exception_info(
+            exception_obj_or_current_frame).__dict__)
     _SAVEFRAME_LOGGER.info("Saving the complete data in the file: %a", filename)
     with _open_file(filename, 'wb') as f:
         pickle.dump(frames_and_exception_info, f, protocol=PICKLE_PROTOCOL)
@@ -857,11 +893,20 @@ def saveframe(filename=None, frames=None, variables=None, exclude_variables=None
     If you have a piece of code that is currently failing due to an issue
     originating from upstream code, and you cannot share your private
     code as a reproducer, use this function to save relevant information to a file.
-    While in an interactive session such as IPython, Jupyter Notebook, or a
-    debugger (pdb/ipdb), you can call this function after your code raised
-    an error to capture and save error frames specific to the upstream codebase
-    Share the generated file with the upstream team, enabling them to reproduce
-    and diagnose the issue independently.
+
+    When to use:
+      - After an Exception:
+        - In an interactive session (IPython, Jupyter Notebook, pdb/ipdb),
+          after your code raises an error, call this function to capture and
+          save error frames specific to the upstream code.
+        - Share the generated file with the upstream team, enabling them to
+          reproduce and diagnose the issue independently.
+      -  Without an Exception:
+        - Even if no error has occurred, you can deliberately enter a debugger
+          (e.g., using ``ipdb.set_trace()``) and save the frames.
+        - This can be used in case you are experiencing slowness in the upstream
+          code. Save the frames using this function to provide the upstream team
+          with relevant information for further investigation.
 
     Information saved in the file:
     --------------------------------------------------------------------------
@@ -908,6 +953,9 @@ def saveframe(filename=None, frames=None, variables=None, exclude_variables=None
       - 'variables' key in each frame's entry stores the local variables of that frame.
       - The 'exception_object' key stores the actual exception object but without
         the __traceback__ info (for security reasons).
+      - Exception info (such as 'exception_*') will not be stored in the file if
+        you enter the debugger manually (e.g., using ``ipdb.set_trace()``) and
+        call ``saveframe`` without an exception being raised.
 
     **Example usage**:
 
@@ -924,6 +972,8 @@ def saveframe(filename=None, frames=None, variables=None, exclude_variables=None
 
       >> <Your code raised an error>
       >> ipdb.pm() # start a debugger
+      >> OR
+      >> <You entered the debugger using ipdb.set_trace()>
       >> ipdb> from pyflyby import saveframe
       >> ipdb> saveframe(filename=/path/to/file) # Saves the frame which you are currently at
       >> ipdb> saveframe(filename=/path/to/file, frames=frames_to_save,
@@ -1044,31 +1094,41 @@ def saveframe(filename=None, frames=None, variables=None, exclude_variables=None
     :return:
       The file path in which the frame info is saved.
     """
+    current_frame = None
+    exception_obj = None
+    # Boolean to denote if an exception has been raised.
+    exception_raised = True
     if not ((sys.version_info < (3, 12) and hasattr(sys, 'last_value')) or
             (sys.version_info >= (3, 12) and hasattr(sys, 'last_exc'))):
-        raise RuntimeError(
-            "No exception is raised currently for which to save the frames. "
-            "Make sure that an uncaught exception is raised before calling the "
-            "`saveframe` function.")
-    # Get the latest exception raised.
-    exception_obj = sys.last_value if sys.version_info < (3, 12) else sys.last_exc
+        exception_raised = False
 
-    if frames is None:
+    if exception_raised:
+        # Get the latest exception raised.
+        exception_obj = sys.last_value if sys.version_info < (3, 12) else sys.last_exc
+    else:
         # Get the instance of the interactive session the user is currently in.
         interactive_session_obj = sys._getframe().f_back.f_back.f_locals.get('self')
         # If the user is currently in a debugger (ipdb/pdb), save the frame the
         # user is currently at in the debugger.
         if interactive_session_obj and hasattr(interactive_session_obj, 'curframe'):
             current_frame = interactive_session_obj.curframe
-            frames = (f"{current_frame.f_code.co_filename}:{current_frame.f_lineno}:"
-                      f"{_get_qualname(current_frame)}")
+        else:
+            raise RuntimeError(
+                "No exception has been raised, and the session is not currently "
+                "within a debugger. Unable to save frames.")
+
+    if frames is None and current_frame is not None:
+        frames = (f"{current_frame.f_code.co_filename}:{current_frame.f_lineno}:"
+                  f"{_get_qualname(current_frame)}")
 
     _SAVEFRAME_LOGGER.info("Validating arguments passed.")
     filename, frames, variables, exclude_variables = _validate_saveframe_arguments(
         filename, frames, variables, exclude_variables)
-    _SAVEFRAME_LOGGER.info(
-        "Saving frames and metadata for the exception: %a", exception_obj)
+    if exception_raised:
+        _SAVEFRAME_LOGGER.info(
+            "Saving frames and metadata for the exception: %a", exception_obj)
     _save_frames_and_exception_info_to_file(
         filename=filename, frames=frames, variables=variables,
-        exclude_variables=exclude_variables, exception_obj=exception_obj)
+        exclude_variables=exclude_variables,
+        exception_obj_or_current_frame=exception_obj or current_frame)
     return filename

--- a/tests/test_saveframe.py
+++ b/tests/test_saveframe.py
@@ -532,9 +532,8 @@ def test_saveframe_no_error_raised(tmpdir):
     with pytest.raises(RuntimeError) as err:
         exec(f"from {pkg_name} import init_func2; init_func2()")
         saveframe()
-    err_msg = ("No exception is raised currently for which to save the frames. "
-               "Make sure that an uncaught exception is raised before calling "
-               "the `saveframe` function.")
+    err_msg = ("No exception has been raised, and the session is not currently "
+               "within a debugger. Unable to save frames.")
     assert str(err.value) == err_msg
 
 


### PR DESCRIPTION
**Background:**
In commit ca62d4f, we created `pyflyby.saveframe` utility to save stack frames when an exception is raised.

**Ehancement:**
- In this commit we enhanced the `saveframe` function to allow saving frames even when no exception is raised.
- Users can now add a `breakpoint()` / `ipdb.set_trace()` in a function, step into the debugger, and call `saveframe` to save one or more frames.
- In this context, the frame at which saveframe is called is considered the first frame from the bottom (frame index = 1).
- For this case, we dp not store any exception metadata in the pickle file (e.g., exception_string, exception_object, etc.) as no exception is raised.

Request: PyInf#14772