### PR TITLE
[ENH] Make py virtualenv aware

### DIFF
--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -280,10 +280,10 @@ Examples
 
 
 
-import warnings
-from pathlib import Path
 from   functools                import total_ordering
+from   pathlib                  import Path
 from   typing                   import Any
+import warnings
 
 from   pyflyby._util            import cmp
 from   shlex                    import quote as shquote
@@ -1479,7 +1479,7 @@ def _init_virtualenv():
 
     warnings.warn(
         "Attempting to work in a virtualenv. If you encounter problems, "
-        "please install IPython inside the virtualenv."
+        "please install pyflyby inside the virtualenv."
     )
     import site
     sys.path.insert(0, virtual_env)

--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -280,6 +280,8 @@ Examples
 
 
 
+import warnings
+from pathlib import Path
 from   functools                import total_ordering
 from   typing                   import Any
 
@@ -1410,12 +1412,112 @@ def print_result(result, output_mode):
         raise AssertionError("unexpected output_mode=%r" % (output_mode,))
 
 
+def _get_virtualenv_site_packages():
+    """
+    Get the site-packages directory of the current virtualenv if we're in one.
+    Returns None if we're not in a virtualenv.
+    """
+    # Check if we're in a virtualenv
+    if not hasattr(sys, 'real_prefix') and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+        return None
+
+    # Get the site-packages directory
+    for path in sys.path:
+        if path.endswith('site-packages') and sys.prefix in path:
+            return path
+    return None
+
+def _add_virtualenv_site_packages():
+    """
+    Add the virtualenv's site-packages to sys.path if we're in a virtualenv.
+    This is similar to IPython's virtualenv support.
+    """
+    site_packages = _get_virtualenv_site_packages()
+    if site_packages and site_packages not in sys.path:
+        sys.path.insert(0, site_packages)
+
+def _get_path_links(p: Path):
+    """Gets path links including all symlinks.
+
+    Adapted from `IPython.core.interactiveshell.InteractiveShell.get_path_links`.
+    """
+    paths = [p]
+    while p.is_symlink():
+        new_path = Path(os.readlink(p))
+        if not new_path.is_absolute():
+            new_path = p.parent / new_path
+        p = new_path
+        paths.append(p)
+    return paths
+
+
+def _init_virtualenv():
+    """Add the current virtualenv to sys.path so the user can import modules from it.
+
+    A warning will appear suggesting the user installs IPython in the
+    virtualenv, but for many cases, it probably works well enough.
+
+    Adapted `IPython.core.interactiveshell.InteractiveShell.init_virtualenv`.
+    """
+    if 'VIRTUAL_ENV' not in os.environ:
+        # Not in a virtualenv
+        return
+    elif os.environ["VIRTUAL_ENV"] == "":
+        warnings.warn("Virtual env path set to '', please check if this is intended.")
+        return
+
+    p = Path(sys.executable)
+    p_venv = Path(os.environ["VIRTUAL_ENV"]).resolve()
+
+    # fallback venv detection:
+    # stdlib venv may symlink sys.executable, so we can't use realpath.
+    # but others can symlink *to* the venv Python, so we can't just use sys.executable.
+    # So we just check every item in the symlink tree (generally <= 3)
+    paths = _get_path_links(p)
+
+    # In Cygwin paths like "c:\..." and '\cygdrive\c\...' are possible
+    if len(p_venv.parts) > 2 and p_venv.parts[1] == "cygdrive":
+        drive_name = p_venv.parts[2]
+        p_venv = (drive_name + ":/") / Path(*p_venv.parts[3:])
+
+    if any(p_venv == p.parents[1].resolve() for p in paths):
+        # Our exe is inside or has access to the virtualenv, don't need to do anything.
+        return
+
+    if sys.platform == "win32":
+        virtual_env = str(Path(os.environ["VIRTUAL_ENV"], "Lib", "site-packages"))
+    else:
+        virtual_env_path = Path(
+            os.environ["VIRTUAL_ENV"], "lib", "python{}.{}", "site-packages"
+        )
+        p_ver = sys.version_info[:2]
+
+        # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
+        re_m = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
+        if re_m:
+            predicted_path = Path(str(virtual_env_path).format(*re_m.groups()))
+            if predicted_path.exists():
+                p_ver = re_m.groups()
+
+        virtual_env = str(virtual_env_path).format(*p_ver)
+
+    warnings.warn(
+        "Attempting to work in a virtualenv. If you encounter problems, "
+        "please install IPython inside the virtualenv."
+    )
+    import site
+    sys.path.insert(0, virtual_env)
+    site.addsitedir(virtual_env)
+
+
 class _Namespace(object):
 
     def __init__(self):
+        _init_virtualenv()
         self.globals      = {"__name__": "__main__",
                              "__builtin__": builtins,
                              "__builtins__": builtins}
+        self.locals       = {}
         self.autoimported = {}
 
     def auto_import(self, arg):
@@ -1456,8 +1558,8 @@ class _Namespace(object):
             _handle_user_exception()
 
     def __repr__(self):
-        return "<{} object at 0x{:0x} \nglobals:{} \nautoimported:{}>".format(
-            type(self).__name__, id(self), self.globals, self.autoimported
+        return "<{} object at 0x{:0x} \nglobals:{} \nlocals:{} \nautoimported:{}>".format(
+            type(self).__name__, id(self), self.globals, self.locals, self.autoimported
         )
 
 
@@ -1687,7 +1789,7 @@ class _PyMain(object):
     def start_ipython(self, args=[]):
         user_ns = self.namespace.globals
         start_ipython_with_autoimporter(args, _user_ns=user_ns,
-                                        app=self.ipython_app)
+                                      app=self.ipython_app)
         # Don't need to do another interactive session after this one
         # (i.e. make 'py --interactive' the same as 'py').
         self.interactive = False

--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -1412,30 +1412,6 @@ def print_result(result, output_mode):
         raise AssertionError("unexpected output_mode=%r" % (output_mode,))
 
 
-def _get_virtualenv_site_packages():
-    """
-    Get the site-packages directory of the current virtualenv if we're in one.
-    Returns None if we're not in a virtualenv.
-    """
-    # Check if we're in a virtualenv
-    if not hasattr(sys, 'real_prefix') and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
-        return None
-
-    # Get the site-packages directory
-    for path in sys.path:
-        if path.endswith('site-packages') and sys.prefix in path:
-            return path
-    return None
-
-def _add_virtualenv_site_packages():
-    """
-    Add the virtualenv's site-packages to sys.path if we're in a virtualenv.
-    This is similar to IPython's virtualenv support.
-    """
-    site_packages = _get_virtualenv_site_packages()
-    if site_packages and site_packages not in sys.path:
-        sys.path.insert(0, site_packages)
-
 def _get_path_links(p: Path):
     """Gets path links including all symlinks.
 
@@ -1517,7 +1493,6 @@ class _Namespace(object):
         self.globals      = {"__name__": "__main__",
                              "__builtin__": builtins,
                              "__builtins__": builtins}
-        self.locals       = {}
         self.autoimported = {}
 
     def auto_import(self, arg):
@@ -1558,8 +1533,8 @@ class _Namespace(object):
             _handle_user_exception()
 
     def __repr__(self):
-        return "<{} object at 0x{:0x} \nglobals:{} \nlocals:{} \nautoimported:{}>".format(
-            type(self).__name__, id(self), self.globals, self.locals, self.autoimported
+        return "<{} object at 0x{:0x} \nglobals:{} \nautoimported:{}>".format(
+            type(self).__name__, id(self), self.globals, self.autoimported
         )
 
 
@@ -1789,7 +1764,7 @@ class _PyMain(object):
     def start_ipython(self, args=[]):
         user_ns = self.namespace.globals
         start_ipython_with_autoimporter(args, _user_ns=user_ns,
-                                      app=self.ipython_app)
+                                        app=self.ipython_app)
         # Don't need to do another interactive session after this one
         # (i.e. make 'py --interactive' the same as 'py').
         self.interactive = False

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -5,6 +5,7 @@
 
 
 
+import ast
 import os
 import pytest
 from   shutil                   import rmtree
@@ -2735,6 +2736,67 @@ def test_apply_not_a_function():
     assert "NotAFunctionError: ('Not a function', 75650517)" in result
 
 
+def test_virtualenv_recognized(tmpdir, monkeypatch):
+    """Verify that virtualenv sys.path is set correctly, and that warnings are emitted."""
+    if os.environ.get("VIRTUAL_ENV") is not None:
+        old_path = os.environ["PATH"].split(os.pathsep)
+        new_path = os.pathsep.join(old_path[1:])
+
+        monkeypatch.delenv("VIRTUAL_ENV")
+        monkeypatch.setenv("PATH", new_path)
+
+    no_venv_stdout = py('print(sys.path)')
+    no_venv_sys_path = ast.literal_eval(no_venv_stdout.split('\n')[-1])
+
+    env_dir = os.path.join(tmpdir, "venv")
+    env_bin = os.path.join(env_dir, "Scripts" if os.name == "nt" else "bin")
+    venv.create(env_dir)
+
+    # Simulate activation
+    monkeypatch.setenv("VIRTUAL_ENV", env_dir)
+    monkeypatch.setenv("PATH", env_bin + os.pathsep + os.environ["PATH"])
+
+    venv_stdout = py('print(sys.path)')
+    venv_sys_path = ast.literal_eval(venv_stdout.split('\n')[-1])
+
+    # Check that the appropriate warning is in place when using the venv,
+    # and missing if not.
+    warning =  (
+        "UserWarning: Attempting to work in a virtualenv. "
+        "If you encounter problems, please install pyflyby inside the virtualenv."
+    )
+    assert warning not in no_venv_stdout
+    assert warning in venv_stdout
+
+    # Check that sys.path printed from the subprocess contains the same
+    # paths as what we have in the test process
+    for path in sys.path:
+
+        # If a path is missing from one, it must be missing from the other
+        # (because both are called in subprocesses, which means that e.g.
+        # the pyenv bin path won't be included in the subprocess call but
+        # will be in the pytest call that runs this test)
+        if path not in no_venv_stdout:
+            assert path not in venv_stdout
+        else:
+            assert path in venv_stdout
+            assert path in no_venv_stdout
+
+    # Check that sys.path of the non-virtualenv appears
+    # in the sys.path of the virtualenv
+    #
+    # Get the last line (which contains the printed sys.path); convert
+    # back into a list
+    # for path in no_venv_sys_path:
+    #     assert path in
+    assert all(path in venv_sys_path for path in no_venv_sys_path)
+
+    # Check that the virtualenv directory appears in the sys.path of
+    # the virtualenv, but not in the sys.path of the non-virtualenv
+    assert not any(env_dir in path for path in no_venv_sys_path)
+    assert any(env_dir in path for path in venv_sys_path)
+
+
 # TODO: test timeit, time
 # TODO: test --attach
 # TODO: test postmortem debugging
@@ -2751,61 +2813,3 @@ def test_apply_not_a_function():
 # TODO: test py -i 'code ...'
 # TODO: test 'py -i' == 'py' (no double shell)
 # TODO: exiting debugger with EOF (control-D)
-
-def test_virtualenv_recognized(tmpdir, monkeypatch):
-    """Verify that virtualenv sys.path is set correctly, and that warnings are emitted."""
-    if os.environ.get("VIRTUAL_ENV") is not None:
-        old_path = os.environ["PATH"].split(os.pathsep)
-        new_path = os.pathsep.join(old_path[1:])
-
-        monkeypatch.delenv("VIRTUAL_ENV")
-        monkeypatch.setenv("PATH", new_path)
-
-    no_venv_stdout = py('print(sys.path)')
-
-    env_dir = os.path.join(tmpdir, "venv")
-    env_bin = os.path.join(env_dir, "Scripts" if os.name == "nt" else "bin")
-    venv.create(env_dir)
-
-    # Simulate activation
-    monkeypatch.setenv("VIRTUAL_ENV", env_dir)
-    monkeypatch.setenv("PATH", env_bin + os.pathsep + os.environ["PATH"])
-
-    venv_stdout = py('print(sys.path)')
-
-    # Check that the appropriate warning is in place when using the venv,
-    # and missing if not.
-    warning =  (
-        "UserWarning: Attempting to work in a virtualenv. "
-        "If you encounter problems, please install IPython inside the virtualenv."
-    )
-    assert warning not in no_venv_stdout
-    assert warning in venv_stdout
-
-    # Check that sys.path printed from the subprocess contains the same
-    # paths as what we have in the test process
-    for path in sys.path:
-
-        # If a path if missing from one, it must be missing from the other
-        # (because both are called in subprocesses, which means that e.g.
-        # the pyenv bin path won't be included in the subprocess call but
-        # will be in the pytest call that runs this test)
-        if path not in no_venv_stdout:
-            assert path not in venv_stdout
-        else:
-            assert path in venv_stdout
-            assert path in no_venv_stdout
-
-    # Check that sys.path of the non-virtualenv appears
-    # in the sys.path of the virtualenv
-    #
-    # Get the last line (which contains the printed sys.path); remove the
-    # square brackets at beginning and end which are printed because
-    # sys.path is a list
-    no_venv_stdout_path = no_venv_stdout.split('\n')[-1][1:-1]
-    assert no_venv_stdout_path in venv_stdout.split('\n')[-1]
-
-    # Check that the virtualenv directory appears in the sys.path of
-    # the virtualenv, but not in the sys.path of the non-virtualenv
-    assert env_dir not in no_venv_stdout
-    assert env_dir in venv_stdout

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -2787,8 +2787,6 @@ def test_virtualenv_recognized(tmpdir, monkeypatch):
     #
     # Get the last line (which contains the printed sys.path); convert
     # back into a list
-    # for path in no_venv_sys_path:
-    #     assert path in
     assert all(path in venv_sys_path for path in no_venv_sys_path)
 
     # Check that the virtualenv directory appears in the sys.path of

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -2750,3 +2750,24 @@ def test_apply_not_a_function():
 # TODO: test py -i 'code ...'
 # TODO: test 'py -i' == 'py' (no double shell)
 # TODO: exiting debugger with EOF (control-D)
+
+def test_virtualenv_site_packages_1():
+    # Verify that virtualenv site-packages are added to sys.path
+    result = py('-q', '--print', 'import sys; print([p for p in sys.path if "site-packages" in p])')
+    site_packages = [p for p in sys.path if "site-packages" in p]
+    assert any(p in result for p in site_packages)
+
+def test_virtualenv_import_1():
+    # Verify that we can import packages from virtualenv
+    result = py('-q', '--print', 'import sys; print(sys.prefix in sys.path)')
+    assert result.strip() == "True"
+
+def test_virtualenv_prefix_unchanged_1():
+    # Verify that sys.prefix and sys.exec_prefix are unchanged
+    result = py('-q', '--print', 'import sys; print(sys.prefix == sys.exec_prefix)')
+    assert result.strip() == "True"
+
+def test_virtualenv_ipython_1():
+    # Verify that virtualenv support works in IPython mode
+    result = py('-i', '-q', '--print', 'import sys; print(sys.prefix in sys.path)')
+    assert result.strip() == "True"


### PR DESCRIPTION
This PR makes `py` virtualenv aware when running scripts or expressions.

```bash
$ source ./venv/bin/activate
$ py b64decode aGVsbG8=
/home/pdmurray/Desktop/workspace/pyflyby/lib/python/pyflyby/_py.py:1504: UserWarning: Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv.
  warnings.warn(
[PYFLYBY] from base64 import b64decode
[PYFLYBY] b64decode('aGVsbG8=', altchars=None, validate=False)
b'hello'

$ py 'print(sys.path)'
/home/pdmurray/Desktop/workspace/pyflyby/lib/python/pyflyby/_py.py:1504: UserWarning: Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv.
  warnings.warn(
[PYFLYBY] import sys
[PYFLYBY] print(sys.path)
['/home/pdmurray/Desktop/workspace/pyflyby/venv/lib/python3.12/site-packages', '/home/pdmurray/.pyenv/versions/3.12.4/envs/pyflyby/bin', '/home/pdmurray/.pyenv/versions/3.12.4/envs/pyflyby/lib/python3.12/site-packages/_pdbpp_path_hack', '/home/pdmurray/.pyenv/versions/3.12.4/lib/python312.zip', '/home/pdmurray/.pyenv/versions/3.12.4/lib/python3.12', '/home/pdmurray/.pyenv/versions/3.12.4/lib/python3.12/lib-dynload', '/home/pdmurray/.pyenv/versions/3.12.4/envs/pyflyby/lib/python3.12/site-packages', '/home/pdmurray/Desktop/workspace/pyflyby/lib/python']
```