### PR TITLE
[BUG] Make `tidy-imports` respect width parameter without pyproject.toml

### DIFF
--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -207,7 +207,7 @@ def parse_args(
                          help=hfmt('''
                              (Default) Don't align the 'from __future__ import
                              ...' statement.'''))
-        group.add_option('--width', type='int', default=None, metavar='N',
+        group.add_option('--width', type='int', default=79, metavar='N',
                          help=hfmt('''
                              Maximum line length (default: 79).'''))
         group.add_option('--black', action='store_true', default=False,

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -207,7 +207,7 @@ def parse_args(
                          help=hfmt('''
                              (Default) Don't align the 'from __future__ import
                              ...' statement.'''))
-        group.add_option('--width', type='int', default=79, metavar='N',
+        group.add_option('--width', type='int', default=None, metavar='N',
                          help=hfmt('''
                              Maximum line length (default: 79).'''))
         group.add_option('--black', action='store_true', default=False,

--- a/lib/python/pyflyby/_format.py
+++ b/lib/python/pyflyby/_format.py
@@ -5,7 +5,8 @@
 
 
 class FormatParams(object):
-    max_line_length = 79
+    max_line_length = None
+    max_line_length_default = 79
     wrap_paren = True
     indent = 4
     hanging_indent = 'never'
@@ -127,10 +128,15 @@ def pyfill(prefix, tokens, params=FormatParams()):
     :rtype:
       ``str``
     """
+    if params.max_line_length is None:
+        max_line_length = params.max_line_length_default
+    else:
+        max_line_length = params.max_line_length
+
     if params.wrap_paren:
         # Check how we will break up the tokens.
         len_full = sum(len(tok) for tok in tokens) + 2 * (len(tokens)-1)
-        if len(prefix) + len_full <= params.max_line_length:
+        if len(prefix) + len_full <= max_line_length:
             # The entire thing fits on one line; no parens needed.  We check
             # this first because breaking into lines adds paren overhead.
             #
@@ -151,7 +157,7 @@ def pyfill(prefix, tokens, params=FormatParams()):
             # longest token since even if the first token fits, we still want
             # to avoid later tokens running over N.
             maxtoklen = max(len(token) for token in tokens)
-            hanging_indent = (len(prefix) + maxtoklen + 2 > params.max_line_length)
+            hanging_indent = (len(prefix) + maxtoklen + 2 > max_line_length)
         else:
             raise ValueError("bad params.hanging_indent=%r"
                              % (params.hanging_indent,))
@@ -164,7 +170,7 @@ def pyfill(prefix, tokens, params=FormatParams()):
             #       abc, defgh, ijkl,
             #       mnopq, rst)
             return (prefix + "(\n"
-                    + fill(tokens, max_line_length=params.max_line_length,
+                    + fill(tokens, max_line_length=max_line_length,
                            prefix=(" " * params.indent), suffix=("", ")")))
         else:
             # Non-hanging-indent mode.
@@ -174,7 +180,7 @@ def pyfill(prefix, tokens, params=FormatParams()):
             #                    ijkl, mnopq,
             #                    rst)
             pprefix = prefix + "("
-            return fill(tokens, max_line_length=params.max_line_length,
+            return fill(tokens, max_line_length=max_line_length,
                         prefix=(pprefix, " " * len(pprefix)), suffix=("", ")"))
     else:
         raise NotImplementedError

--- a/lib/python/pyflyby/_format.py
+++ b/lib/python/pyflyby/_format.py
@@ -5,8 +5,7 @@
 
 
 class FormatParams(object):
-    max_line_length = None
-    _max_line_lenght_default = 79
+    max_line_length = 79
     wrap_paren = True
     indent = 4
     hanging_indent = 'never'
@@ -128,11 +127,10 @@ def pyfill(prefix, tokens, params=FormatParams()):
     :rtype:
       ``str``
     """
-    N = params.max_line_length or params._max_line_lenght_default
     if params.wrap_paren:
         # Check how we will break up the tokens.
         len_full = sum(len(tok) for tok in tokens) + 2 * (len(tokens)-1)
-        if len(prefix) + len_full <= N:
+        if len(prefix) + len_full <= params.max_line_length:
             # The entire thing fits on one line; no parens needed.  We check
             # this first because breaking into lines adds paren overhead.
             #
@@ -153,7 +151,7 @@ def pyfill(prefix, tokens, params=FormatParams()):
             # longest token since even if the first token fits, we still want
             # to avoid later tokens running over N.
             maxtoklen = max(len(token) for token in tokens)
-            hanging_indent = (len(prefix) + maxtoklen + 2 > N)
+            hanging_indent = (len(prefix) + maxtoklen + 2 > params.max_line_length)
         else:
             raise ValueError("bad params.hanging_indent=%r"
                              % (params.hanging_indent,))
@@ -166,7 +164,7 @@ def pyfill(prefix, tokens, params=FormatParams()):
             #       abc, defgh, ijkl,
             #       mnopq, rst)
             return (prefix + "(\n"
-                    + fill(tokens, max_line_length=N,
+                    + fill(tokens, max_line_length=params.max_line_length,
                            prefix=(" " * params.indent), suffix=("", ")")))
         else:
             # Non-hanging-indent mode.
@@ -176,7 +174,7 @@ def pyfill(prefix, tokens, params=FormatParams()):
             #                    ijkl, mnopq,
             #                    rst)
             pprefix = prefix + "("
-            return fill(tokens, max_line_length=N,
+            return fill(tokens, max_line_length=params.max_line_length,
                         prefix=(pprefix, " " * len(pprefix)), suffix=("", ")"))
     else:
         raise NotImplementedError

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -588,7 +588,11 @@ class ImportStatement:
         black_config = read_black_config()
         mode = dict()
 
-        mode["line_length"] = black_config.get("line_length", params.max_line_length)
+        if params.max_line_length is None:
+            mode["line_length"] = black_config.get("line_length", params.max_line_length_default)
+        else:
+            mode["line_length"] = params.max_line_length
+
         if "target_version" in black_config:
             if isinstance(black_config["target_version"], set):
                 target_versions_in = black_config["target_version"]

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -587,15 +587,8 @@ class ImportStatement:
 
         black_config = read_black_config()
         mode = dict()
-        if "line_length" in black_config:
-            mode["line_length"] = (
-                params.max_line_length
-                if params.max_line_length
-                else black_config["line_length"]
-            )
-        else:
-            mode["line_length"] = params.max_line_length
 
+        mode["line_length"] = black_config.get("line_length", params.max_line_length)
         if "target_version" in black_config:
             if isinstance(black_config["target_version"], set):
                 target_versions_in = black_config["target_version"]

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -512,7 +512,7 @@ class ImportStatement:
 
         return tuple(self.aliases[0][0].split('.'))
 
-        
+
     def _cmp(self):
         """
         Comparison function for sorting.
@@ -593,6 +593,9 @@ class ImportStatement:
                 if params.max_line_length
                 else black_config["line_length"]
             )
+        else:
+            mode["line_length"] = params.max_line_length
+
         if "target_version" in black_config:
             if isinstance(black_config["target_version"], set):
                 target_versions_in = black_config["target_version"]

--- a/tests/test_imports2s.py
+++ b/tests/test_imports2s.py
@@ -11,6 +11,7 @@ import sys
 from   textwrap                 import dedent
 import types
 
+from   pyflyby._format          import FormatParams
 from   pyflyby._importdb        import ImportDB
 from   pyflyby._imports2s       import (canonicalize_imports,
                                         fix_unused_and_missing_imports,
@@ -1111,3 +1112,34 @@ def test_fix_unused_imports_submodule_importas_1():
         m2.x + m2y + m3.x
     '''))
     assert expected == output
+
+
+def test_reformat_import_statements_respect_width_1(tmp_path):
+    """Test that tidy-imports with a max line length correctly wraps imports."""
+    filename = str(tmp_path / "test_reformat_import_statements_respect_width_1")
+    input = PythonBlock(dedent('''
+        from math import sin,cos,tan,sinh,cosh,tanh,log,floor,log10,remainder,factorial,nextafter,radians
+        assert [sin,cos,tan,sinh,cosh,tanh,log,floor,log10,remainder,factorial,nextafter,radians]
+    ''').lstrip(), filename=filename)
+    output = reformat_import_statements(input, FormatParams(max_line_length=100))
+    expected = PythonBlock(dedent('''
+        from math import (cos, cosh, factorial, floor, log, log10, nextafter, radians, remainder, sin, sinh,
+                          tan, tanh)
+        assert [sin,cos,tan,sinh,cosh,tanh,log,floor,log10,remainder,factorial,nextafter,radians]
+    ''').lstrip(), filename=filename)
+    assert output == expected
+
+
+def test_reformat_import_statements_respect_width_2(tmp_path):
+    """Test that tidy-imports with a max line length correctly wraps imports."""
+    filename = str(tmp_path / "test_reformat_import_statements_respect_width_2")
+    input = PythonBlock(dedent('''
+        from math import sin,cos,tan,sinh,cosh,tanh,log,floor,log10,remainder,factorial,nextafter,radians
+        assert [sin,cos,tan,sinh,cosh,tanh,log,floor,log10,remainder,factorial,nextafter,radians]
+    ''').lstrip(), filename=filename)
+    output = reformat_import_statements(input, FormatParams(max_line_length=200))
+    expected = PythonBlock(dedent('''
+        from math import cos, cosh, factorial, floor, log, log10, nextafter, radians, remainder, sin, sinh, tan, tanh
+        assert [sin,cos,tan,sinh,cosh,tanh,log,floor,log10,remainder,factorial,nextafter,radians]
+    ''').lstrip(), filename=filename)
+    assert output == expected

--- a/tests/test_imports2s.py
+++ b/tests/test_imports2s.py
@@ -1143,3 +1143,19 @@ def test_reformat_import_statements_respect_width_2(tmp_path):
         assert [sin,cos,tan,sinh,cosh,tanh,log,floor,log10,remainder,factorial,nextafter,radians]
     ''').lstrip(), filename=filename)
     assert output == expected
+
+
+def test_reformat_import_statements_respect_width_3(tmp_path):
+    """Test that tidy-imports with no specified width matches the default width."""
+    filename = str(tmp_path / "test_reformat_import_statements_respect_width_3")
+    input = PythonBlock(dedent('''
+        from math import sin,cos,tan,sinh,cosh,tanh,log,floor,log10,remainder,factorial,nextafter,radians
+        assert [sin,cos,tan,sinh,cosh,tanh,log,floor,log10,remainder,factorial,nextafter,radians]
+    ''').lstrip(), filename=filename)
+    assert reformat_import_statements(
+        input,
+        FormatParams(max_line_length=None),
+    ) == reformat_import_statements(
+        input,
+        FormatParams(max_line_length=FormatParams.max_line_length_default),
+    )

--- a/tests/test_importstmt.py
+++ b/tests/test_importstmt.py
@@ -123,8 +123,31 @@ def test_Import_replace_2():
 
 @patch("pyflyby._importstmt.read_black_config", lambda: {"line_length": 20})
 def test_Import_black_line_length():
+    """Test that a black config takes precedence over the default line length."""
     stmt = Import("from a123456789 import b123456789")
     result = stmt.pretty_print(params=FormatParams(use_black=True))
+    assert result == "from a123456789 import (\n    b123456789,\n)\n"
+
+
+@patch("pyflyby._importstmt.read_black_config", lambda: {})
+def test_Import_black_line_length2():
+    """Test that the default line length is used if no black config is present."""
+    stmt = Import("from math import sincostansinhcoshtanhlogfloorlog10remainderfactorialnextafter")
+    result = stmt.pretty_print(params=FormatParams(use_black=True))
+    assert result == "from math import sincostansinhcoshtanhlogfloorlog10remainderfactorialnextafter\n"
+
+@patch("pyflyby._importstmt.read_black_config", lambda: {})
+def test_Import_black_line_length3():
+    """Test that the default line length is used if no black config is present."""
+    stmt = Import("from math import sincostansinhcoshtanhlogfloorlog10remainderfactorialnextafterradians")
+    result = stmt.pretty_print(params=FormatParams(use_black=True))
+    assert result == "from math import (\n    sincostansinhcoshtanhlogfloorlog10remainderfactorialnextafterradians,\n)\n"
+
+@patch("pyflyby._importstmt.read_black_config", lambda: {"line_length": 200})
+def test_Import_black_line_length4():
+    """Test that a command line --width takes precedence over a black config."""
+    stmt = Import("from a123456789 import b123456789")
+    result = stmt.pretty_print(params=FormatParams(use_black=True, max_line_length=20))
     assert result == "from a123456789 import (\n    b123456789,\n)\n"
 
 


### PR DESCRIPTION
This makes `tidy-imports` respect the specified `--width` without requiring `pyproject.toml` to be present.

Closes #385.