### PR TITLE
Re-integrate pyflyby with IPython completer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 .. image:: https://travis-ci.org/deshaw/pyflyby.png?branch=master
    :target: https://travis-ci.org/deshaw/pyflyby
 
-Pyflyby is a set of Python programming productivity tools for Python 3.8+.
+Pyflyby is a set of Python programming productivity tools for Python 3.9+.
 
 For command-line interaction:
   * ``py``: command-line multitool
@@ -248,6 +248,10 @@ Other IPython magic commands work as well::
   [PYFLYBY] from numpy import arange
   [0 1 2 3]
 
+.. warning::
+
+    Auto-import on :kbd:`Tab` completion require IPython 9.3 or newer.
+
 
 Implementation details
 ----------------------
@@ -258,7 +262,7 @@ namespace never contains entries for names that are not yet imported.
 This method of importing at parse time contrasts with previous implementations
 of automatic importing that use proxy objects.  Those implementations using
 proxy objects don't work as well, because it is impossible to make proxy
-objects behave perfectly.  For example, instance(x, T) will return the wrong
+objects behave perfectly.  For example, ``instance(x, T)`` will return the wrong
 answer if either x or T is a proxy object.
 
 
@@ -266,9 +270,8 @@ Compatibility
 -------------
 
 Tested with:
-  - Python 3.8, 3.9, 3.10
-  - IPython 0.10, 0.11, 0.12, 0.13, 1.0, 1.2, 2.0, 2.1, 2.2, 2.3, 2.4, 3.0,
-    3.1, 3.2, 4.0., 7.11 (latest)
+  - Python 3.9, 3.10, 3.11, 3.12
+  - IPython 8.18, 8.37.0, 9.4.0 (latest)
   - IPython (text console), IPython Notebook, Spyder
 
 

--- a/README.rst
+++ b/README.rst
@@ -252,7 +252,7 @@ Other IPython magic commands work as well::
 
 .. warning::
 
-    Auto-import on :kbd:`Tab` completion require IPython 9.3 or newer.
+    Auto-import on :kbd:`Tab` completion requires IPython 9.3 or newer.
 
 
 Implementation details

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -502,7 +502,6 @@ def debugger(*args, **kwargs):
     if arg is None and tty is not None and wait_for_attach != True:
         # If _waiting_for_debugger is not None, then attach to that
         # (whether it's a frame, traceback, etc).
-        global _waiting_for_debugger
         arg = _waiting_for_debugger
         _debugger_attached = True
     if arg is None:

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -8,6 +8,7 @@ import ast
 import builtins
 from   contextlib               import contextmanager
 import errno
+import functools
 import inspect
 import os
 import operator
@@ -757,9 +758,9 @@ class NamespaceWithPotentialImports(dict):
     def __init__(self, values, ip):
         dict.__init__(values)
         self._ip = ip
-        self._potential_imports_list = self._generate_potential_imports_list()
 
-    def _generate_potential_imports_list(self):
+    @functools.cached_property
+    def _potential_imports_list(self):
         """Collect symbols that could be imported into the namespace."""
         # TODO: should it run on each invocation, or can it run just once?
         db = None

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -1781,6 +1781,15 @@ class AutoImporter:
             completer.policy_overrides.update({"allow_auto_import": True})
             completer.auto_import_method = "pyflyby._interactive._auto_import_hook"
 
+        if getattr(completer, 'use_jedi', False):
+            # IPython 6.0+ uses jedi completion by default, which bypasses
+            # the global and attr matchers. For now we manually reenable
+            # them. A TODO would be to hook the Jedi completer itself.
+            if completer.python_matcher not in completer.matchers:
+                @self._advise(type(completer).matchers)
+                def matchers_with_python_matches(completer):
+                    return __original__.fget(completer) + [completer.python_matcher]
+
         from IPython.utils import generics
 
         @generics.complete_object.register(object)

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -1763,8 +1763,8 @@ class AutoImporter:
         # manages, is not useful because that only works for specific commands.
         # (A "command" refers to the first word on a line, such as "cd".)
         #
-        # We avoid advising attr_matches() and minimise inference with
-        # global_matches(), because these are not public API hooks,
+        # We avoid advising attr_matcher() and minimise inference with
+        # global_matcher(), because these are not public API hooks,
         # and contain a lot of logic which would need to be reproduced
         # here for high quality completions in edge cases.
         #
@@ -1795,7 +1795,7 @@ class AutoImporter:
             # them. A TODO would be to hook the Jedi completer itself.
             if completer.python_matcher not in completer.matchers:
                 @self._advise(type(completer).matchers)
-                def matchers_with_python_matches(completer):
+                def matchers_with_python_matcher(completer):
                     return __original__.fget(completer) + [completer.python_matcher]
 
         @self._advise(completer.global_matches)
@@ -1819,7 +1819,6 @@ class AutoImporter:
                 return words
             with InterceptPrintsDuringPromptCtx(self._ip):
                 logger.debug("complete_object_hook(%r)", obj)
-                namespaces = ScopeStack(get_global_namespaces(self._ip))
                 # Get the database of known imports.
                 db = ImportDB.interpret_arg(None, target_filename=".")
                 known = db.known_imports

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -1776,8 +1776,10 @@ class AutoImporter:
         #   * auto_import_method - for auto-import
         logger.debug("_enable_completer_hooks(%r)", completer)
 
-        completer.policy_overrides.update({"allow_auto_import": True})
-        completer.auto_import_method = "pyflyby._interactive._auto_import_hook"
+        if hasattr(completer, "policy_overrides"):
+            # `policy_overrides` and `auto_import_method` were added in IPython 9.3
+            completer.policy_overrides.update({"allow_auto_import": True})
+            completer.auto_import_method = "pyflyby._interactive._auto_import_hook"
 
         from IPython.utils import generics
 

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -18,10 +18,10 @@ import sys
 from typing import List, Any, Dict, Union, Literal
 
 
-from   pyflyby._autoimp         import (LoadSymbolError, ScopeStack, auto_eval,
+from   pyflyby._autoimp         import (ScopeStack,
                                         auto_import,
-                                        clear_failed_imports_cache,
-                                        load_symbol)
+                                        auto_import_symbol,
+                                        clear_failed_imports_cache)
 from   pyflyby._dynimp          import (inject as inject_dynamic_import, 
                                         PYFLYBY_LAZY_LOAD_PREFIX)
 from   pyflyby._comms           import (initialize_comms, remove_comms,
@@ -484,12 +484,6 @@ def _install_in_ipython_config_file_40():
         logger.info("[DONE] Removed old file %s (moved to %s)", old_fn, trash_fn)
 
 
-
-
-
-
-
-
 def _ipython_in_multiline(ip):
     """
     Return ``False`` if the user has entered only one line of input so far,
@@ -759,79 +753,23 @@ def get_global_namespaces(ip):
         return [builtins.__dict__, __main__.__dict__]
 
 
-def complete_symbol(fullname, namespaces, db=None, autoimported=None, ip=None,
-                    allow_eval=False):
-    """
-    Enumerate possible completions for ``fullname``.
+class NamespaceWithPotentialImports(dict):
+    def __init__(self, values, ip):
+        dict.__init__(values)
+        self._ip = ip
+        self._potential_imports_list = self._generate_potential_imports_list()
 
-    Includes globals and auto-importable symbols.
-
-      >>> complete_symbol("threadi", [{}])                # doctest:+ELLIPSIS
-      [...'threading'...]
-
-    Completion works on attributes, even on modules not yet imported - modules
-    are auto-imported first if not yet imported::
-
-      >>> ns = {}
-      >>> complete_symbol("threading.Threa", namespaces=[ns])
-      [PYFLYBY] import threading
-      ['threading.Thread', 'threading.ThreadError']
-
-      >>> 'threading' in ns
-      True
-
-      >>> complete_symbol("threading.Threa", namespaces=[ns])
-      ['threading.Thread', 'threading.ThreadError']
-
-    We only need to import *parent* modules (packages) of the symbol being
-    completed.  If the user asks to complete "foo.bar.quu<TAB>", we need to
-    import foo.bar, but we don't need to import foo.bar.quux.
-
-    :type fullname:
-      ``str``
-    :param fullname:
-      String to complete.  ("Full" refers to the fact that it should contain
-      dots starting from global level.)
-    :type namespaces:
-      ``dict`` or ``list`` of ``dict``
-    :param namespaces:
-      Namespaces of (already-imported) globals.
-    :type db:
-      `importDB`
-    :param db:
-      Import database to use.
-    :type ip:
-      ``InteractiveShell``
-    :param ip:
-      IPython shell instance if in IPython; ``None`` to assume not in IPython.
-    :param allow_eval:
-      Whether to allow evaluating code, which is necessary to allow completing
-      e.g. 'foo[0].bar<TAB>' or 'foo().bar<TAB>'.  Note that IPython will only
-      pass such strings if IPCompleter.greedy is configured to True by the
-      user.
-    :rtype:
-      ``list`` of ``str``
-    :return:
-      Completion candidates.
-    """
-    namespaces = ScopeStack(namespaces)
-    logger.debug("complete_symbol(%r)", fullname)
-    splt = fullname.rsplit(".", 1)
-    attrname = splt[-1]
-    # The right-hand-side of the split (the part to complete, possibly the
-    # fullname) must be a prefix of a valid symbol.  Otherwise don't bother
-    # generating completions.
-    # As for the left-hand-side of the split, load_symbol() will validate it
-    # or evaluate it depending on ``allow_eval``.
-    if not is_identifier(attrname, prefix=True):
-        return []
-    # Get the database of known imports.
-    db = ImportDB.interpret_arg(db, target_filename=".")
-    known = db.known_imports
-    if len(splt) == 1:
+    def _generate_potential_imports_list(self):
+        """Collect symbols that could be imported into the namespace."""
+        # TODO: should it run on each invocation, or can it run just once?
+        db = None
+        db = ImportDB.interpret_arg(db, target_filename=".")
+        known = db.known_imports
         # Check global names, including global-level known modules and
         # importable modules.
         results = set()
+        namespaces = get_global_namespaces(self._ip)
+        namespaces = ScopeStack(namespaces)
         for ns in namespaces:
             for name in ns:
                 if '.' not in name:
@@ -839,94 +777,38 @@ def complete_symbol(fullname, namespaces, db=None, autoimported=None, ip=None,
         results.update(known.member_names.get("", []))
         results.update([str(m) for m in ModuleHandle.list()])
         assert all('.' not in r for r in results)
-        results = sorted([r for r in results if r.startswith(attrname)])
-    elif len(splt) == 2:
-        # Check members, including known sub-modules and importable sub-modules.
-        pname = splt[0]
-        if allow_eval:
-            # Evaluate the parent, with autoimporting.
-            ns_g, ns_l = namespaces.merged_to_two()
-            # TODO: only catch exceptions around the eval, not the other stuff
-            # (loading import db, etc).
-            try:
-                parent = auto_eval(pname, globals=ns_g, locals=ns_l, db=db)
-            except Exception as e:
-                logger.debug("complete_symbol(%r): couldn't evaluate %r: %s: %s",
-                             fullname, pname, type(e).__name__, e)
-                return []
-        else:
-            try:
-                parent = load_symbol(pname, namespaces, autoimport=True, db=db,
-                                     autoimported=autoimported)
-            except LoadSymbolError as e2:
-                # Even after attempting auto-import, the symbol is still
-                # unavailable, or some other error occurred.  Nothing to complete.
-                e3 = getattr(e2, "__cause__", e2)
-                logger.debug("complete_symbol(%r): couldn't load symbol %r: %s: %s",
-                             fullname, pname, type(e3).__name__, e3)
-                return []
-        logger.debug("complete_symbol(%r): %s == %r", fullname, pname, parent)
-        results = set()
-        # Add current attribute members.
-        results.update(_list_members_for_completion(parent, ip))
-        # Is the parent a package/module?
-        if sys.modules.get(pname, Ellipsis) is parent and parent.__name__ == pname:
-            # Add known_imports entries from the database.
-            results.update(known.member_names.get(pname, []))
-            # Get the module handle.  Note that we use ModuleHandle() on the
-            # *name* of the module (``pname``) instead of the module instance
-            # (``parent``).  Using the module instance normally works, but
-            # breaks if the module hackily replaced itself with a pseudo
-            # module (e.g. https://github.com/josiahcarlson/mprop).
-            pmodule = ModuleHandle(pname)
-            # Add importable submodules.
-            results.update([m.name.parts[-1] for m in pmodule.submodules])
-        results = sorted([r for r in results if r.startswith(attrname)])
-        results = ["%s.%s" % (pname, r) for r in results]
-    else:
-        raise AssertionError
-    logger.debug("complete_symbol(%r) => %r", fullname, results)
-    return results
+        results = sorted([r for r in results])
+        return results
+
+    def keys(self):
+        return list(dict.keys(self)) + self._potential_imports_list
 
 
-def _list_members_for_completion(obj, ip):
-    """
-    Enumerate the existing member attributes of an object.
-    This emulates the regular Python/IPython completion items.
-
-    It does not include not-yet-imported submodules.
-
-    :param obj:
-      Object whose member attributes to enumerate.
-    :rtype:
-      ``list`` of ``str``
-    """
-    if ip is None:
-        words = dir(obj)
-    else:
-        try:
-            limit_to__all__ = ip.Completer.limit_to__all__
-        except AttributeError:
-            limit_to__all__ = False
-        if limit_to__all__ and hasattr(obj, '__all__'):
-            words = getattr(obj, '__all__')
-        elif "IPython.core.error" in sys.modules:
-            from IPython.utils import generics
-            from IPython.utils.dir2 import dir2
-            from IPython.core.error import TryNext
-            words = dir2(obj)
-            try:
-                words = generics.complete_object(obj, words)
-            except TryNext:
-                pass
-        else:
-            words = dir(obj)
-    return [w for w in words if isinstance(w, str)]
+def _auto_import_hook(name: str):
+    logger.debug("_auto_import_hook(%r)", name)
+    ip = _get_ipython_app().shell
+    try:
+        namespaces = get_global_namespaces(ip)
+        namespaces = ScopeStack(namespaces)
+        db = None
+        db = ImportDB.interpret_arg(db, target_filename='.')
+        did_auto_import = auto_import_symbol(name, namespaces, db)
+    except Exception as e:
+        logger.debug("_auto_import_hook preparation error: %r", e)
+        raise e
+    if not did_auto_import:
+        raise ImportError(f"{name} not auto-imported")
+    try:
+        # relies on `auto_import_symbol` auto-importing into [-1] namespace
+        return namespaces[-1][name]
+    except Exception as e:
+        logger.debug("_auto_import_hook internal error: %r", e)
+        raise e
 
 
 def _auto_import_in_pdb_frame(pdb_instance, arg):
     frame = pdb_instance.curframe
-    namespaces = [ frame.f_globals, pdb_instance.curframe_locals ]
+    namespaces = [frame.f_globals, pdb_instance.curframe_locals]
     filename = frame.f_code.co_filename
     if not filename or filename.startswith("<"):
         filename = "."
@@ -1861,6 +1743,7 @@ class AutoImporter:
             logger.debug("Couldn't enable prun hook")
             return False
 
+
     def _enable_completer_hooks(self, completer):
         # Hook a completer instance.
         #
@@ -1881,54 +1764,55 @@ class AutoImporter:
         # manages, is not useful because that only works for specific commands.
         # (A "command" refers to the first word on a line, such as "cd".)
         #
-        # We choose to advise global_matches() and attr_matches(), which are
-        # called to enumerate global and non-global attribute symbols
-        # respectively.  (python_matches() calls these two.  We advise
-        # global_matches() and attr_matches() instead of python_matches()
-        # because a few other functions call global_matches/attr_matches
-        # directly.)
+        # We choose NOT to advise global_matches() and attr_matches(),
+        # which are called to enumerate global and non-global attribute
+        # symbols respectively, because these are not public API hooks,
+        # and contain a lot of logic which would need to be reproduced
+        # here for high quality completions in edge cases.
+        #
+        # Instead, we hook into three public APIs:
+        #   * generics.complete_object - for attribute completion
+        #   * global_namespace - for completion of modules before they get imported
+        #   * auto_import_method - for auto-import
         logger.debug("_enable_completer_hooks(%r)", completer)
-        if hasattr(completer, "global_matches"):
-            # Tested with IPython 0.10, 0.11, 0.12, 0.13, 1.0, 1.2, 2.0, 2.3,
-            # 2.4, 3.0, 3.1, 3.2, 4.0, 5.8.
-            try:
-                completer.shell.pt_cli
-                is_pt = True
-            except AttributeError:
-                is_pt = False
-            if is_pt:
-                def get_completer_namespaces():
-                    return [completer.namespace, completer.global_namespace]
-            else:
-                def get_completer_namespaces():
-                    # For non-prompt_toolkit, (1) completer.namespace is not
-                    # reliable inside pdb, and (2) _get_pdb_if_is_in_pdb() is
-                    # reliable inside pdb because no threading.
-                    # Use get_global_namespaces(), which relies on
-                    # _get_pdb_if_is_in_pdb().
-                    return None
-            if getattr(completer, 'use_jedi', False):
-                # IPython 6.0+ uses jedi completion by default, which bypasses
-                # the global and attr matchers. For now we manually reenable
-                # them. A TODO would be to hook the Jedi completer itself.
-                if completer.python_matches not in completer.matchers:
-                    @self._advise(type(completer).matchers)
-                    def matchers_with_python_matches(completer):
-                        return __original__.fget(completer)+[completer.python_matches]
 
-            @self._advise(completer.global_matches)
-            def global_matches_with_autoimport(fullname):
-                if len(fullname) == 0:
-                    return []
-                logger.debug("global_matches_with_autoimport(%r)", fullname)
-                namespaces = get_completer_namespaces()
-                return self.complete_symbol(fullname, namespaces, on_error=__original__)
-            @self._advise(completer.attr_matches)
-            def attr_matches_with_autoimport(fullname):
-                logger.debug("attr_matches_with_autoimport(%r)", fullname)
-                namespaces = get_completer_namespaces()
-                return self.complete_symbol(fullname, namespaces, on_error=__original__)
+        completer.policy_overrides.update({"allow_auto_import": True})
+        completer.auto_import_method = "pyflyby._interactive._auto_import_hook"
 
+        from IPython.utils import generics
+
+        @generics.complete_object.register(object)
+        def complete_object_hook(obj, words):
+            with InterceptPrintsDuringPromptCtx(self._ip):
+                logger.debug("complete_object_hook(%r)", obj)
+                namespaces = get_global_namespaces(self._ip)
+                namespaces = ScopeStack(namespaces)
+                # Get the database of known imports.
+                db = None
+                db = ImportDB.interpret_arg(db, target_filename=".")
+                known = db.known_imports
+                results = set(words)
+                pname = obj.__name__
+                # Is it a package/module?
+                if sys.modules.get(pname, Ellipsis) is obj:
+                    # Add known_imports entries from the database.
+                    results.update(known.member_names.get(pname, []))
+                    # Get the module handle.  Note that we use ModuleHandle() on the
+                    # *name* of the module (``pname``) instead of the module instance
+                    # (``obj``).  Using the module instance normally works, but
+                    # breaks if the module hackily replaced itself with a pseudo
+                    # module (e.g. https://github.com/josiahcarlson/mprop).
+                    pmodule = ModuleHandle(pname)
+                    # Add importable submodules.
+                    results.update([m.name.parts[-1] for m in pmodule.submodules])
+                results = sorted([r for r in results])
+                return results
+
+        if hasattr(completer, "global_namespace"):
+            completer.global_namespace = NamespaceWithPotentialImports(
+                completer.global_namespace,
+                ip=self._ip
+            )
             return True
         elif hasattr(completer, "complete_request"):
             # This is a ZMQCompleter, so nothing to do.
@@ -2156,22 +2040,6 @@ class AutoImporter:
             raise_on_error=raise_on_error, on_error=on_error,
             post_import_hook=post_import_hook)
 
-    def complete_symbol(self, fullname, namespaces,
-                        raise_on_error='if_debug', on_error=None):
-        with InterceptPrintsDuringPromptCtx(self._ip):
-            if namespaces is None:
-                namespaces = get_global_namespaces(self._ip)
-            if on_error is not None:
-                def on_error1(fullname, namespaces, autoimported, ip, allow_eval):
-                    return on_error(fullname)
-            else:
-                on_error1 = None
-            return self._safe_call(
-                complete_symbol, fullname, namespaces,
-                autoimported=self._autoimported_this_cell,
-                ip=self._ip, allow_eval=True,
-                raise_on_error=raise_on_error, on_error=on_error1)
-
     def compile_with_autoimport(self, src, filename, mode, flags=0):
         logger.debug("compile_with_autoimport(%r)", src)
         ast_node = compile(src, filename, mode, flags|ast.PyCF_ONLY_AST,
@@ -2241,7 +2109,7 @@ def load_ipython_extension(arg=Ellipsis):
 
       In [1]: %reload_ext pyflyby
 
-    To load pyflyby automatically on IPython startup, appendto
+    To load pyflyby automatically on IPython startup, append to
     ~/.ipython/profile_default/ipython_config.py::
       c.InteractiveShellApp.extensions.append("pyflyby")
 

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -771,8 +771,7 @@ class NamespaceWithPotentialImports(dict):
         # Check global names, including global-level known modules and
         # importable modules.
         results = set()
-        namespaces = get_global_namespaces(self._ip)
-        namespaces = ScopeStack(namespaces)
+        namespaces = ScopeStack(get_global_namespaces(self._ip))
         for ns in namespaces:
             for name in ns:
                 if '.' not in name:
@@ -780,21 +779,18 @@ class NamespaceWithPotentialImports(dict):
         results.update(known.member_names.get("", []))
         results.update([str(m) for m in ModuleHandle.list()])
         assert all('.' not in r for r in results)
-        results = sorted([r for r in results])
-        return results
+        return sorted([r for r in results])
 
     def keys(self):
-        return list(dict.keys(self)) + self._potential_imports_list
+        return list(self) + self._potential_imports_list
 
 
 def _auto_import_hook(name: str):
     logger.debug("_auto_import_hook(%r)", name)
     ip = _get_ipython_app().shell
     try:
-        namespaces = get_global_namespaces(ip)
-        namespaces = ScopeStack(namespaces)
-        db = None
-        db = ImportDB.interpret_arg(db, target_filename='.')
+        namespaces = ScopeStack(get_global_namespaces(ip))
+        db = ImportDB.interpret_arg(None, target_filename='.')
         did_auto_import = auto_import_symbol(name, namespaces, db)
     except Exception as e:
         logger.debug("_auto_import_hook preparation error: %r", e)
@@ -1823,11 +1819,9 @@ class AutoImporter:
                 return words
             with InterceptPrintsDuringPromptCtx(self._ip):
                 logger.debug("complete_object_hook(%r)", obj)
-                namespaces = get_global_namespaces(self._ip)
-                namespaces = ScopeStack(namespaces)
+                namespaces = ScopeStack(get_global_namespaces(self._ip))
                 # Get the database of known imports.
-                db = None
-                db = ImportDB.interpret_arg(db, target_filename=".")
+                db = ImportDB.interpret_arg(None, target_filename=".")
                 known = db.known_imports
                 results = set(words)
                 pname = obj.__name__

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -1784,7 +1784,7 @@ class AutoImporter:
             completer.policy_overrides.update({"allow_auto_import": True})
             completer.auto_import_method = "pyflyby._interactive._auto_import_hook"
 
-        if getattr(completer, 'use_jedi', False):
+        if getattr(completer, 'use_jedi', False) and hasattr(completer, 'python_matcher'):
             # IPython 6.0+ uses jedi completion by default, which bypasses
             # the global and attr matchers. For now we manually reenable
             # them. A TODO would be to hook the Jedi completer itself.

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1838,7 +1838,7 @@ def test_autoimport_multiline_continued_statement_1(frontend):
         [PYFLYBY] from base64 import b64decode
         [PYFLYBY] import sys
         microphone
-        In [3]: if 1: sys.stdout.write(b64decode('bG91ZHNwZWFrZXI='))
+        In [3]: if 1: sys.stdout.buffer.write(b64decode('bG91ZHNwZWFrZXI='))
         loudspeaker
     """, frontend=frontend)
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -3927,8 +3927,9 @@ def test_debug_postmortem_tab_completion_1(frontend):
         [PYFLYBY] import base64
         ecode"""
     scenario_b = """
-        ipdb> func = base64.b64d\x06ecode
-        [PYFLYBY] import base64"""
+        ipdb> func = base64.b64d\x06;
+        [PYFLYBY] import base64
+        ;"""
     try:
         ipython(template.format(scenario_a), frontend=frontend)
     except pytest.fail.Exception:

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -181,8 +181,6 @@ def assert_match(result, expected, ignore_prompt_number=False):
 
     if _IPYTHON_VERSION < (1, 0):
         assert False, "we don't support IPython pre  1.0 anymore"
-    if _IPYTHON_VERSION < (0, 12):
-        assert False, "we don't support IPython pre  1.0 anymore"
         # Ignore the "Compiler time: 0.123 s" which may occasionally appear
     # depending on runtime.
     regexp = re.sub(re.compile(br"^(1[\\]* loops[\\]*,[\\]* best[\\]* of[\\]* 1[\\]*:[\\]* .*[\\]* per[\\]* loop)($|[$]|[\\]*\n)", re.M),

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -437,6 +437,10 @@ try:
 except AttributeError:
     _IPYTHON_VERSION = _parse_version(IPython.__version__)
 
+
+# `policy_overrides` and `auto_import_method` were added in IPython 9.3
+_SUPPORTS_TAB_AUTO_IMPORT = _IPYTHON_VERSION < (9, 3)
+
 # Prompts that we expect for.
 _IPYTHON_PROMPT1 = br"\n\r?In \[([0-9]+)\]: "
 _IPYTHON_PROMPT2 = br"\n\r?   [.][.][.]+: "
@@ -1616,9 +1620,6 @@ def test_ipython_version_1():
 
 @retry
 def test_autoimport_1():
-    if _IPYTHON_VERSION < (9, 3):
-        # `policy_overrides` and `auto_import_method` were added in IPython 9.3
-        pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: b'@'+b64decode('SGVsbG8=')+b'@'
@@ -2134,6 +2135,7 @@ def test_autoimport_multiple_candidates_multi_joinpoint_repeated_1(tmp):
     )
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_basic_1():
     # Verify that tab completion works.
@@ -2145,6 +2147,7 @@ def test_complete_symbol_basic_1():
     """)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_multiple_1(frontend):
     ipython("""
@@ -2157,6 +2160,7 @@ def test_complete_symbol_multiple_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_partial_multiple_1(frontend):
     ipython("""
@@ -2169,6 +2173,7 @@ def test_complete_symbol_partial_multiple_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_import_check_1():
     # Check importing into the namespace.  If we use b64decode from base64,
@@ -2190,6 +2195,7 @@ def test_complete_symbol_import_check_1():
     """)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_instance_identity_1():
     # Verify that automatic symbols give the same instance (i.e., no proxy
@@ -2203,6 +2209,7 @@ def test_complete_symbol_instance_identity_1():
     """)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_member_1(frontend):
     # Verify that tab completion in members works.
@@ -2221,6 +2228,7 @@ def test_complete_symbol_member_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_member_multiple_1(frontend):
     ipython(
@@ -2240,6 +2248,7 @@ def test_complete_symbol_member_multiple_1(frontend):
     )
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_member_partial_multiple_1(frontend):
     ipython(
@@ -2259,6 +2268,7 @@ def test_complete_symbol_member_partial_multiple_1(frontend):
     )
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_import_module_as_1(frontend, tmp):
     writetext(tmp.file, "import base64 as b64\n")
@@ -2271,6 +2281,7 @@ def test_complete_symbol_import_module_as_1(frontend, tmp):
     """, PYFLYBY_PATH=tmp.file, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_statement_1():
     # Verify that tab completion in statements works.  This requires a more
@@ -2284,6 +2295,7 @@ def test_complete_symbol_statement_1():
     """)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_multiline_statement_1():
     ipython("""
@@ -2300,6 +2312,7 @@ def test_complete_symbol_multiline_statement_1():
     """)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_multiline_statement_member_1(frontend):
     ipython("""

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1534,6 +1534,7 @@ def test_ipython_tab_fail_1(frontend):
     )
 
 
+@pytest.mark.skipif(_IPYTHON_VERSION < (8, 27), reason='Multi-option tests are written for IPython 8.27+')
 @retry
 def test_ipython_tab_multi_1(frontend):
     # Test that our test harness works for tab when there are multiple matches
@@ -1550,7 +1551,9 @@ def test_ipython_tab_multi_1(frontend):
         AttributeError: 'function' object has no attribute 'xyz'
     """, frontend=frontend, args=['--IPCompleter.use_jedi=False'])
 
-#@retry
+
+@pytest.mark.skipif(_IPYTHON_VERSION < (8, 27), reason='Multi-option tests are written for IPython 8.27+')
+@retry
 def test_ipython_tab_multi_2(frontend):
     # Test that our test harness works for tab when there are multiple matches
     # for tab completion. This test checks if multiple suggestions are shown.
@@ -2339,7 +2342,7 @@ def test_complete_symbol_autocall_arg_1():
             Out[2]: b'CHEWBACCA'
         """, autocall=True)
     else:
-        # IPython 7.17+ shoudl have fixed double autocall
+        # IPython 7.17+ should have fixed double autocall
         ipython("""
             In [1]: import pyflyby; pyflyby.enable_auto_importer()
             In [2]: bytes.upper b64deco\tde('Q2hld2JhY2Nh')
@@ -2349,6 +2352,7 @@ def test_complete_symbol_autocall_arg_1():
         """, autocall=True)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_any_module_1(frontend, tmp):
     # Verify that completion and autoimport works for an arbitrary module in
@@ -2364,6 +2368,7 @@ def test_complete_symbol_any_module_1(frontend, tmp):
     """, PYTHONPATH=tmp.dir, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_any_module_member_1(frontend, tmp):
     # Verify that completion on members works for an arbitrary module in
@@ -2380,6 +2385,7 @@ def test_complete_symbol_any_module_member_1(frontend, tmp):
     """, PYTHONPATH=tmp.dir, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_bad_1(frontend, tmp):
     # Verify that if we have a bad item in known imports, we complete it still.
@@ -2401,6 +2407,7 @@ def test_complete_symbol_bad_1(frontend, tmp):
     )
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_bad_as_1(frontend, tmp):
     writetext(tmp.file, "import foo_86487172 as bar_98073069_quux\n")
@@ -2458,6 +2465,7 @@ def test_complete_symbol_greedy_eval_1():
     """)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 def test_complete_symbol_greedy_eval_autoimport_1(frontend):
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
@@ -2469,6 +2477,7 @@ def test_complete_symbol_greedy_eval_autoimport_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_error_in_getattr_1(frontend):
     # Verify that if there's an exception inside some custom object's getattr,
@@ -2536,6 +2545,7 @@ def test_disable_reenable_autoimport_1():
     )
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_disable_reenable_completion_1():
     ipython(
@@ -2961,6 +2971,7 @@ def test_timeit_complete_menu_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_IPYTHON_VERSION < (8, 27), reason='Multi-option tests are written for IPython 8.27+')
 @retry
 def test_timeit_complete_autoimport_member_1(frontend):
     ipython("""
@@ -3051,6 +3062,7 @@ def test_time_complete_menu_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_IPYTHON_VERSION < (8, 27), reason='Multi-option tests are written for IPython 8.27+')
 @retry
 def test_time_complete_autoimport_member_1(frontend):
     ipython("""
@@ -3864,6 +3876,7 @@ def test_debug_tab_completion_multiple_1(frontend, tmp):
     """, PYTHONPATH=tmp.dir, frontend=frontend)
 
 
+@retry
 def test_debug_postmortem_tab_completion_1(frontend):
     # Verify that tab completion in %debug postmortem mode works.
     ipython("""
@@ -3888,6 +3901,7 @@ def test_debug_postmortem_tab_completion_1(frontend):
     """, frontend=frontend)
 
 
+@retry
 def test_debug_namespace_1_py3(frontend):
     # Verify that autoimporting and tab completion happen in the local
     # namespace.
@@ -3919,6 +3933,7 @@ def test_debug_namespace_1_py3(frontend):
     """, frontend=frontend)
 
 
+@retry
 def test_debug_second_1(frontend):
     # Verify that a second postmortem debug of the same function behaves as
     # expected.

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -3043,7 +3043,8 @@ def test_time_complete_menu_1(frontend):
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: time b64\t
-        b64decode  b64encode
+        In [2]: time b64
+        b64decode b64encode
         In [2]: time b64\x06d\tecode('cGFudHM=')
         [PYFLYBY] from base64 import b64decode
         CPU times: ...
@@ -3056,10 +3057,10 @@ def test_time_complete_menu_1(frontend):
 def test_time_complete_autoimport_member_1(frontend):
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
-        In [2]: time base64.b6\t
+        In [2]: time base64.b64\t
+        In [2]: time base64.b64
+        .b64decode .b64encode
         [PYFLYBY] import base64
-        In [2]: time base64.b6
-        base64.b64decode  base64.b64encode
         In [2]: time base64.b64\x06dec\tode('amFja2V0')
         CPU times: ...
         Wall time: ...
@@ -3804,7 +3805,7 @@ def test_debug_postmortem_auto_import_1(frontend):
     """, frontend=frontend)
 
 
-@retry
+@pytest.mark.xfail(IPython.version_info >= (8, 14), reason='not working on tab completion since https://github.com/ipython/ipython/pull/13889')
 def test_debug_tab_completion_db_1(frontend):
     # Verify that tab completion from database works.
     ipython("""

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -34,6 +34,7 @@ from   typing                   import Union
 
 # To debug test_interactive.py itself, set the env var DEBUG_TEST_PYFLYBY.
 DEBUG = bool(os.getenv("DEBUG_TEST_PYFLYBY"))
+_TESTED_EVALUATION_SETTINGS = ['greedy=True', "evaluation='limited'"]
 
 _env_timeout = os.getenv("PYFLYBYTEST_DEFAULT_TIMEOUT", None)
 if _env_timeout is not None:
@@ -2456,21 +2457,24 @@ def test_complete_symbol_getitem_no_jedi_1(frontend):
             frontend=frontend)
 
 
-def test_complete_symbol_greedy_eval_1():
-    ipython("""
+@pytest.mark.parametrize('evaluation', _TESTED_EVALUATION_SETTINGS)
+def test_complete_symbol_eval_1(evaluation):
+    ipython(f"""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
-        In [2]: %config IPCompleter.greedy=True
+        In [2]: %config IPCompleter.{evaluation}
         In [3]: apple = 'Fuji'
         In [4]: apple.lower()[0].stri\tp()
         Out[4]: 'f'
     """)
 
 
+
 @pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
-def test_complete_symbol_greedy_eval_autoimport_1(frontend):
-    ipython("""
+@pytest.mark.parametrize('evaluation', _TESTED_EVALUATION_SETTINGS)
+def test_complete_symbol_eval_autoimport_1(frontend, evaluation):
+    ipython(f"""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
-        In [2]: %config IPCompleter.greedy=True
+        In [2]: %config IPCompleter.{evaluation}
         In [3]: os.sep.strip().lst\t
         [PYFLYBY] import os
         In [3]: os.sep.strip().lst\trip

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -2946,6 +2946,7 @@ def test_timeit_1():
     """)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_timeit_complete_1(frontend):
     # Verify that tab completion works with %timeit.
@@ -2957,6 +2958,7 @@ def test_timeit_complete_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_timeit_complete_menu_1(frontend):
     # Verify that menu tab completion works with %timeit.
@@ -3033,6 +3035,7 @@ def test_time_repeat_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_time_complete_1(frontend):
     # Verify that tab completion works with %time.
@@ -3046,6 +3049,7 @@ def test_time_complete_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_time_complete_menu_1(frontend):
     # Verify that menu tab completion works with %time.
@@ -3815,6 +3819,7 @@ def test_debug_postmortem_auto_import_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 def test_debug_tab_completion_db_1(frontend):
     # Verify that tab completion from database works.
     ipython("""
@@ -3831,6 +3836,7 @@ def test_debug_tab_completion_db_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 def test_debug_tab_completion_module_1(frontend, tmp):
     # Verify that tab completion on module names works.
     writetext(tmp.dir/"thornton60097181.py", """
@@ -3852,6 +3858,7 @@ def test_debug_tab_completion_module_1(frontend, tmp):
     """, PYTHONPATH=tmp.dir, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_debug_tab_completion_multiple_1(frontend, tmp):
     # Verify that tab completion with ambiguous names works.
@@ -3876,6 +3883,7 @@ def test_debug_tab_completion_multiple_1(frontend, tmp):
     """, PYTHONPATH=tmp.dir, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_debug_postmortem_tab_completion_1(frontend):
     # Verify that tab completion in %debug postmortem mode works.
@@ -3901,6 +3909,7 @@ def test_debug_postmortem_tab_completion_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_debug_namespace_1_py3(frontend):
     # Verify that autoimporting and tab completion happen in the local
@@ -3933,6 +3942,7 @@ def test_debug_namespace_1_py3(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_debug_second_1(frontend):
     # Verify that a second postmortem debug of the same function behaves as

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -3927,9 +3927,8 @@ def test_debug_postmortem_tab_completion_1(frontend):
         [PYFLYBY] import base64
         ecode"""
     scenario_b = """
-        ipdb> func = base64.b64d\x06;
-        [PYFLYBY] import base64
-        ;"""
+        ipdb> func = base64.b64decode
+        [PYFLYBY] import base64"""
     try:
         ipython(template.format(scenario_a), frontend=frontend)
     except pytest.fail.Exception:

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -2428,6 +2428,7 @@ def test_complete_symbol_bad_as_1(frontend, tmp):
     )
 
 
+@retry
 def test_complete_symbol_getitem_1(frontend):
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
@@ -2973,6 +2974,7 @@ def test_timeit_complete_menu_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @pytest.mark.skipif(_IPYTHON_VERSION < (8, 27), reason='Multi-option tests are written for IPython 8.27+')
 @retry
 def test_timeit_complete_autoimport_member_1(frontend):
@@ -3066,6 +3068,7 @@ def test_time_complete_menu_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @pytest.mark.skipif(_IPYTHON_VERSION < (8, 27), reason='Multi-option tests are written for IPython 8.27+')
 @retry
 def test_time_complete_autoimport_member_1(frontend):
@@ -3928,7 +3931,7 @@ def test_debug_postmortem_tab_completion_1(frontend):
         [PYFLYBY] import base64"""
     try:
         ipython(template.format(scenario_a), frontend=frontend)
-    except Exception:
+    except pytest.fail.Exception:
         ipython(template.format(scenario_b), frontend=frontend)
 
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1827,8 +1827,8 @@ def test_autoimport_multiline_continued_statement_1(frontend):
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: if 1:
            ...:     (sys.
-           ...:         stdout.
-           ...:             buffer.
+           ...:         stdout
+           ...:             .buffer
            ...:                 .write(
            ...:                     b64decode(
            ...:                         'bWljcm9waG9uZQ==')))

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -193,6 +193,7 @@ def assert_match(result, expected, ignore_prompt_number=False):
     regexp = re.compile(regexp)
     result = b'\n'.join(line.rstrip() for line in result.splitlines())
     result = result.strip()
+
     if DEBUG:
         print("expected: %r" % (expected,))
         print("result  : %r" % (result,))
@@ -682,8 +683,6 @@ class AnsiFilterDecoder(object):
             start, stop = match.start(), match.end()
             arg = arg[:start]+n_spaces*b' '+arg[stop:]
             match = re.search(pat, arg)
-
-
 
         arg = re.sub(br"\n\x1b\[[0-9]*C", b"", arg) # move cursor right immediately after a newline
         # Cursor movement. We assume this is used only for places that have '...'
@@ -2327,6 +2326,7 @@ def test_complete_symbol_multiline_statement_member_1(frontend):
     """, frontend=frontend)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_complete_symbol_autocall_arg_1():
     # Verify that tab completion works with autocall.
@@ -3294,6 +3294,7 @@ def test_ipython_notebook_reconnect_1():
         """, args=['console'], kernel=kernel)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_py_interactive_1():
     # Verify that 'py' enables pyflyby autoimporter at start.
@@ -3377,6 +3378,7 @@ def test_py_notebook_1():
         """, args=['console'], kernel=kernel)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_py_disable_1():
     # Verify that when using 'py', we can disable the autoimporter, and
@@ -3409,6 +3411,7 @@ def _install_load_ext_pyflyby_in_config(ipython_dir):
         print('c.InteractiveShellApp.extensions.append("pyflyby")', file=f)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_installed_in_config_ipython_cmdline_1(tmp):
     # Verify that autoimport works in 'ipython' when pyflyby is installed in
@@ -3431,6 +3434,7 @@ def test_installed_in_config_ipython_cmdline_1(tmp):
     )
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_installed_in_config_redundant_1(tmp):
     # Verify that redundant installations are fine.
@@ -3492,6 +3496,7 @@ def test_installed_in_config_ipython_notebook_1(tmp):
         """, args=['console'], kernel=kernel)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_installed_in_config_disable_1(tmp):
     # Verify that when we've installed, we can still disable at run-time, and
@@ -3520,6 +3525,7 @@ def test_installed_in_config_disable_1(tmp):
     )
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_installed_in_config_enable_noop_1(tmp):
     # Verify that manually calling enable_auto_importer() is a no-op if we've
@@ -3549,6 +3555,7 @@ def test_installed_in_config_enable_noop_1(tmp):
     )
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_installed_in_config_ipython_py_1(tmp):
     # Verify that installation in ipython_config and 'py' are compatible.
@@ -3577,6 +3584,7 @@ def test_installed_in_config_ipython_py_1(tmp):
     )
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_manual_install_profile_startup_1(tmp):
     # Test that manually installing to the startup folder works.
@@ -3590,6 +3598,7 @@ def test_manual_install_profile_startup_1(tmp):
     """, ipython_dir=tmp.ipython_dir)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_manual_install_ipython_config_direct_1(tmp):
     # Verify that manually installing in ipython_config.py works when enabling
@@ -3604,6 +3613,7 @@ def test_manual_install_ipython_config_direct_1(tmp):
     """, ipython_dir=tmp.ipython_dir)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_manual_install_exec_lines_1(tmp):
     writetext(tmp.ipython_dir/"profile_default/ipython_config.py", """
@@ -3619,6 +3629,7 @@ def test_manual_install_exec_lines_1(tmp):
     """, ipython_dir=tmp.ipython_dir)
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_manual_install_exec_files_1(tmp):
     writetext(tmp.file, """
@@ -3639,6 +3650,7 @@ def test_manual_install_exec_files_1(tmp):
 
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_cmdline_enable_c_i_1(tmp):
     ipython("""
@@ -3648,6 +3660,7 @@ def test_cmdline_enable_c_i_1(tmp):
     """, args=['-c', 'import pyflyby; pyflyby.enable_auto_importer()', '-i'])
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 def test_cmdline_enable_code_to_run_i_1(tmp):
     ipython("""
         In [1]: b64deco\tde('cm90dHdlaWxlcg==')
@@ -3657,6 +3670,7 @@ def test_cmdline_enable_code_to_run_i_1(tmp):
                'import pyflyby; pyflyby.enable_auto_importer()', '-i'])
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @retry
 def test_cmdline_enable_exec_lines_1(tmp):
     ipython("""
@@ -3668,6 +3682,7 @@ def test_cmdline_enable_exec_lines_1(tmp):
         '''["__import__('pyflyby').enable_auto_importer()"]'''])
 
 
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 def test_cmdline_enable_exec_files_1(tmp):
     writetext(tmp.file, """
         import pyflyby
@@ -3887,7 +3902,7 @@ def test_debug_tab_completion_multiple_1(frontend, tmp):
 @retry
 def test_debug_postmortem_tab_completion_1(frontend):
     # Verify that tab completion in %debug postmortem mode works.
-    ipython("""
+    template = """
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: def foo(x, y):
            ...:     return x / y
@@ -3899,14 +3914,22 @@ def test_debug_postmortem_tab_completion_1(frontend):
         TypeError: unsupported operand type(s) for /: 'str' and 'str'
         In [4]: %debug
         ....
-        ipdb> func = base64.b64d\t
-        ipdb> func = base64.b64d\x06
-        [PYFLYBY] import base64
-        ecode
+        ipdb> func = base64.b64d\t{0}
         ipdb> print(x + func("Lw==").decode('utf-8') + y)
         Camden/Hopkinson
         ipdb> q
-    """, frontend=frontend)
+    """
+    scenario_a = """
+        ipdb> func = base64.b64d\x06
+        [PYFLYBY] import base64
+        ecode"""
+    scenario_b = """
+        ipdb> func = base64.b64d\x06ecode
+        [PYFLYBY] import base64"""
+    try:
+        ipython(template.format(scenario_a), frontend=frontend)
+    except Exception:
+        ipython(template.format(scenario_b), frontend=frontend)
 
 
 @pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1616,6 +1616,9 @@ def test_ipython_version_1():
 
 @retry
 def test_autoimport_1():
+    if _IPYTHON_VERSION < (9, 3):
+        # `policy_overrides` and `auto_import_method` were added in IPython 9.3
+        pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: b'@'+b64decode('SGVsbG8=')+b'@'

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1624,7 +1624,6 @@ def test_autoimport_1():
     """)
 
 
-# @pytest.mark.skipif(_IPYTHON_VERSION > (8, 0), reason="Strange output missparsing")
 @retry
 def test_no_autoimport_1():
     # Test that without pyflyby installed, we do get NameError.  This is
@@ -1824,7 +1823,6 @@ def test_autoimport_multiline_statement_1():
 
 @retry
 def test_autoimport_multiline_continued_statement_1(frontend):
-    if frontend == "prompt_toolkit": pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: if 1:
@@ -1844,7 +1842,6 @@ def test_autoimport_multiline_continued_statement_1(frontend):
 
 @retry
 def test_autoimport_multiline_continued_statement_fake_1(frontend):
-    if frontend == "prompt_toolkit": pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: if 1:
@@ -2147,7 +2144,6 @@ def test_complete_symbol_basic_1():
 
 @retry
 def test_complete_symbol_multiple_1(frontend):
-    if frontend == "prompt_toolkit": pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: print(b64\t
@@ -2160,7 +2156,6 @@ def test_complete_symbol_multiple_1(frontend):
 
 @retry
 def test_complete_symbol_partial_multiple_1(frontend):
-    if frontend == "prompt_toolkit": pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: print(b6\t
@@ -2225,8 +2220,6 @@ def test_complete_symbol_member_1(frontend):
 
 @retry
 def test_complete_symbol_member_multiple_1(frontend):
-    if frontend == "prompt_toolkit":
-        pytest.skip()
     ipython(
         """
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
@@ -2246,8 +2239,6 @@ def test_complete_symbol_member_multiple_1(frontend):
 
 @retry
 def test_complete_symbol_member_partial_multiple_1(frontend):
-    if frontend == "prompt_toolkit":
-        pytest.skip()
     ipython(
         """
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
@@ -2308,7 +2299,6 @@ def test_complete_symbol_multiline_statement_1():
 
 @retry
 def test_complete_symbol_multiline_statement_member_1(frontend):
-    if frontend == "prompt_toolkit": pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: if 1:
@@ -2423,8 +2413,6 @@ def test_complete_symbol_bad_as_1(frontend, tmp):
 
 
 def test_complete_symbol_getitem_1(frontend):
-    if frontend == "prompt_toolkit": pytest.skip()
-    if _IPYTHON_VERSION >= (5,): pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: apples = ['McIntosh', 'PinkLady']
@@ -2447,8 +2435,6 @@ def test_complete_symbol_greedy_eval_1():
 
 
 def test_complete_symbol_greedy_eval_autoimport_1(frontend):
-    if frontend == "prompt_toolkit": pytest.skip()
-    if _IPYTHON_VERSION >= (5,): pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: %config IPCompleter.greedy=True
@@ -2624,7 +2610,6 @@ def test_error_during_auto_import_expression_1(tmp):
 
 @retry
 def test_error_during_completion_1(frontend, tmp):
-    if frontend == "prompt_toolkit": pytest.skip()
     writetext(tmp.file, "3+")
     ipython(
         """
@@ -2941,7 +2926,6 @@ def test_timeit_complete_1(frontend):
 @retry
 def test_timeit_complete_menu_1(frontend):
     # Verify that menu tab completion works with %timeit.
-    if frontend == "prompt_toolkit": pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: timeit -n 2 -r 1 b64\t
@@ -2954,7 +2938,6 @@ def test_timeit_complete_menu_1(frontend):
 
 @retry
 def test_timeit_complete_autoimport_member_1(frontend):
-    if frontend == "prompt_toolkit": pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: timeit -n 2 -r 1 base64.b6\t
@@ -3030,7 +3013,6 @@ def test_time_complete_1(frontend):
 @retry
 def test_time_complete_menu_1(frontend):
     # Verify that menu tab completion works with %time.
-    if frontend == "prompt_toolkit": pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: time b64\t
@@ -3045,7 +3027,6 @@ def test_time_complete_menu_1(frontend):
 
 @retry
 def test_time_complete_autoimport_member_1(frontend):
-    if frontend == "prompt_toolkit": pytest.skip()
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
         In [2]: time base64.b6\t
@@ -3837,7 +3818,6 @@ def test_debug_tab_completion_module_1(frontend, tmp):
 @retry
 def test_debug_tab_completion_multiple_1(frontend, tmp):
     # Verify that tab completion with ambiguous names works.
-    if frontend == "prompt_toolkit": pytest.skip()
     writetext(tmp.dir/"sturbridge9088333.py", """
         nebula_41695458 = 1
         nebula_10983840 = 2


### PR DESCRIPTION
- Alternative to #392
- Closes #397 

Checklist:
- [x] re-enable all previously skipped tests
- [x] remove `greedy` opt-in in tests; parametrize tests to check pyflyby works in all supported evaluation policy modes
- [x] integrate pyflyby completer logic cleanly:
  - use `Completer.auto_import_method` traitlet to hook auto-import logic
      - works with `minimal`, `limited` (default), and `unsafe` evaluation policies (but not `dangerous` which is discouraged)
  - use `generics.complete_object` to hook auto-discovery of submodules logic
     - better than just hooking into `_attr_matches` because it allows to take advantage of built-in `_attr_matches` logic which for example handles operators as in https://github.com/ipython/ipython/pull/14898
   - use `global_namespace.keys()` to hook into auto-discovery of modules logic
- [x] ensure all tests pass
   - [x] fix handling in `%debug`; the namespace would need to be swapped there too.
- [x] implement disabling of the completer customization
- [x] check support for IPython >= 8.0, <9.3: the completer should work even if auto-import does not fully work (as that was only added in IPython 9.3)