### PR TITLE
Remove `toml` dependency in favor of `tomli`

### DIFF
--- a/bin/tidy-imports
+++ b/bin/tidy-imports
@@ -21,11 +21,8 @@ Only top-level import statements are touched.
 # License: MIT http://opensource.org/licenses/MIT
 
 
-from __future__ import print_function
-
-import os
-
-from   pyflyby._cmdline         import hfmt, parse_args, process_actions
+from   pyflyby._cmdline         import (_get_pyproj_toml_config, hfmt,
+                                        parse_args, process_actions)
 from   pyflyby._import_sorting  import sort_imports
 from   pyflyby._imports2s       import (canonicalize_imports,
                                         fix_unused_and_missing_imports,
@@ -33,23 +30,7 @@ from   pyflyby._imports2s       import (canonicalize_imports,
                                         transform_imports)
 from   pyflyby._parse           import PythonBlock
 
-from   pathlib                  import Path
 import tomli
-
-
-def _get_pyproj_toml_config():
-    """
-    Try to find current project pyproject.toml
-    in cwd or parents directories.
-    """
-    cwd = Path(os.getcwd())
-
-    for pth in [cwd] + list(cwd.parents):
-        pyproj_toml = pth /'pyproject.toml'
-        if pyproj_toml.exists() and pyproj_toml.is_file():
-            return pyproj_toml.read_text()
-
-    return None
 
 
 def _addopts(parser):

--- a/bin/tidy-imports
+++ b/bin/tidy-imports
@@ -33,8 +33,8 @@ from   pyflyby._imports2s       import (canonicalize_imports,
                                         transform_imports)
 from   pyflyby._parse           import PythonBlock
 
-import toml
-TOML_AVAIL = True
+from   pathlib                  import Path
+import tomli
 
 
 def _get_pyproj_toml_config():
@@ -42,14 +42,7 @@ def _get_pyproj_toml_config():
     Try to find current project pyproject.toml
     in cwd or parents directories.
     """
-    if not TOML_AVAIL:
-        return None
-
-    from pathlib import Path
-
-
     cwd = Path(os.getcwd())
-
 
     for pth in [cwd] + list(cwd.parents):
         pyproj_toml = pth /'pyproject.toml'
@@ -57,9 +50,6 @@ def _get_pyproj_toml_config():
             return pyproj_toml.read_text()
 
     return None
-
-
-
 
 
 def _addopts(parser):
@@ -140,7 +130,7 @@ def main() -> None:
 
     config_text = _get_pyproj_toml_config()
     if config_text:
-        default_config = toml.loads(config_text).get('tool', {}).get('pyflyby',{})
+        default_config = tomli.loads(config_text).get('tool', {}).get('pyflyby',{})
     else:
         default_config = {}
 
@@ -149,7 +139,10 @@ def main() -> None:
         parser.set_defaults(**default_config)
 
     options, args = parse_args(
-        _add_opts_and_defaults, import_format_params=True, modify_action_params=True, defaults=default_config)
+        _add_opts_and_defaults,
+        import_format_params=True,
+        modify_action_params=True,
+    )
 
     def modify(block:PythonBlock) -> PythonBlock:
         if options.transformations:
@@ -166,13 +159,13 @@ def main() -> None:
         # TODO: disable sorting until we figure out #287
         # https://github.com/deshaw/pyflyby/issues/287
 
-        # here we get a (single?) PythonBlock, we can access each statement with 
+        # here we get a (single?) PythonBlock, we can access each statement with
         # >>> block.statements
         # and each statement can have a:
         # is_import
         # or
         # is_comment or blank
-        
+
         # TODO: we do Python(str(...)) in order to unparse-reparse and get proper ast node numbers.
         if options.experimental_sort_imports:
             sorted_imports = PythonBlock(str(sort_imports(block)))

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -37,16 +37,10 @@ def _sigpipe_handler(*args):
     raise SystemExit(1)
 
 
-def parse_args(
-    addopts=None, import_format_params=False, modify_action_params=False, defaults=None
-):
+def parse_args(addopts=None, import_format_params=False, modify_action_params=False):
     """
     Do setup for a top-level script and parse arguments.
     """
-
-    if defaults is None:
-        defaults = {}
-
     ### Setup.
     # Register a SIGPIPE handler.
     signal.signal(signal.SIGPIPE, _sigpipe_handler)

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -7,6 +7,7 @@
 from   builtins                 import input
 import optparse
 import os
+from   pathlib                  import Path
 import signal
 import sys
 from   textwrap                 import dedent
@@ -526,3 +527,17 @@ symlink_callbacks = {
     'skip': symlink_skip,
     'replace': symlink_replace,
 }
+
+def _get_pyproj_toml_config():
+    """
+    Try to find current project pyproject.toml
+    in cwd or parents directories.
+    """
+    cwd = Path(os.getcwd())
+
+    for pth in [cwd] + list(cwd.parents):
+        pyproj_toml = pth /'pyproject.toml'
+        if pyproj_toml.exists() and pyproj_toml.is_file():
+            return pyproj_toml.read_text()
+
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]
-files = ['lib']
+files = ["lib"]
 #warn_incomplete_stub = false
 warn_unused_configs = true
 #ignore_missing_imports = true
-follow_imports = 'silent'
+follow_imports = "silent"
 # disallow_untyped_defs = true
 # ignore_errors = false
 # ignore_missing_imports = false

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ setup(
     ],
     install_requires=[
             "six",
-            "toml",
+            "tomli",
             "black",
             "typing_extensions>=4.6; python_version<'3.12'"
     ],

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import tempfile
 from   textwrap                 import dedent
-from   unittest                 import mock
 
 from   pyflyby._cmdline         import _get_pyproj_toml_config
 from   pyflyby._util            import CwdCtx, EnvVarCtx
@@ -927,11 +926,4 @@ def test_load_pyproject_toml(tmp_path, pyproject_text):
         f.write(pyproject_text)
 
     os.chdir(tmp_path)
-    with mock.patch("os.getcwd", wraps=os.getcwd) as mock_getcwd:
-        text = _get_pyproj_toml_config()
-
-    mock_getcwd.assert_called_once()
-    assert text == pyproject_text
-
-    # Check that the mock points to the temp path
-    assert mock_getcwd() == str(tmp_path)
+    assert _get_pyproj_toml_config() == pyproject_text

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -7,13 +7,15 @@
 
 from   io                       import BytesIO
 import os
-import sys
 import pexpect
 import subprocess
+import sys
 import tempfile
 from   textwrap                 import dedent
+from   unittest                 import mock
 
-from pyflyby._util import EnvVarCtx, CwdCtx
+from   pyflyby._cmdline         import _get_pyproj_toml_config
+from   pyflyby._util            import CwdCtx, EnvVarCtx
 
 import pytest
 
@@ -796,7 +798,7 @@ def test_tidy_imports_forward_references():
                     param1: str
                     param2: B
 
-                                
+
                 class B:
                     param1: str
             """
@@ -834,3 +836,102 @@ def test_tidy_imports_forward_references():
             """
             ).strip()
         assert result == expected
+
+
+@pytest.mark.parametrize(
+    "pyproject_text",
+    [
+        r'''[tool.tox.env_run_base]
+commands = [["{tox_root}{/}run_pytest.py", {replace = "posargs", default = ["-cvv"], extend = true}]]''',
+        r'''[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+files = ['lib']
+#warn_incomplete_stub = false
+warn_unused_configs = true
+#ignore_missing_imports = true
+follow_imports = 'silent'
+# disallow_untyped_defs = true
+# ignore_errors = false
+# ignore_missing_imports = false
+# disallow_untyped_calls = true
+# disallow_incomplete_defs = true
+# check_untyped_defs = true
+# disallow_untyped_decorators = true
+warn_redundant_casts = true
+exclude = '(?x)(_dbg\.py|_py\.py)'
+
+[[tool.mypy.overrides]]
+module = [
+    "pyflyby._docxref",
+    "pyflyby._interactive",
+]
+ignore_errors = true
+'''
+    ]
+)
+def test_tidy_imports_toml(tmp_path, pyproject_text):
+    """Test that tidy-imports works with a pyproject.toml that has mixed array types."""
+    with open(tmp_path / "pyproject.toml", 'w') as f:
+        f.write(pyproject_text)
+
+    result = pipe([BIN_DIR+"/tidy-imports", "--quiet"], stdin="os, sys", cwd=tmp_path)
+    expected = dedent('''
+        import os
+        import sys
+
+        os, sys
+    ''').strip()
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "pyproject_text",
+    [
+        r'''[tool.tox.env_run_base]
+commands = [["{tox_root}{/}run_pytest.py", {replace = "posargs", default = ["-cvv"], extend = true}]]''',
+        r'''[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+files = ['lib']
+#warn_incomplete_stub = false
+warn_unused_configs = true
+#ignore_missing_imports = true
+follow_imports = 'silent'
+# disallow_untyped_defs = true
+# ignore_errors = false
+# ignore_missing_imports = false
+# disallow_untyped_calls = true
+# disallow_incomplete_defs = true
+# check_untyped_defs = true
+# disallow_untyped_decorators = true
+warn_redundant_casts = true
+exclude = '(?x)(_dbg\.py|_py\.py)'
+
+[[tool.mypy.overrides]]
+module = [
+    "pyflyby._docxref",
+    "pyflyby._interactive",
+]
+ignore_errors = true
+'''
+    ]
+)
+def test_load_pyproject_toml(tmp_path, pyproject_text):
+    """Test that a pyproject.toml that has mixed array types can be loaded."""
+    with open(tmp_path / "pyproject.toml", 'w') as f:
+        f.write(pyproject_text)
+
+    os.chdir(tmp_path)
+    with mock.patch("os.getcwd", wraps=os.getcwd) as mock_getcwd:
+        text = _get_pyproj_toml_config()
+
+    mock_getcwd.assert_called_once()
+    assert text == pyproject_text
+
+    # Check that the mock points to the temp path
+    assert mock_getcwd() == str(tmp_path)


### PR DESCRIPTION
This PR removes `toml` in favor of `tomli`, closing #395.

Additionally:

- Removed the `defaults` kwarg in `_cmdline.parse_args`. It doesn't do anything.
- Moved the `_get_pyproj_toml_config` function out of `tidy-imports` and into `_cmdline.py` so that it can be tested properly.
- Added two new tests using the current project's `pyproject.toml` and a `pyproject.toml` that has mixed types in an array (previously this would have caused `tidy-imports` to fail to run). One test checks that `tidy-imports` runs, and the other checks that `_get_pyproj_toml_config` parses the toml configs just fine.