### PR TITLE
Replace deprecated appdirs dependency with platformdirs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,7 +45,7 @@ autodoc_default_options = {
 
 autodoc_mock_imports = [
     "pyflyby._fast_iter_modules",
-    "appdirs",
+    "platformdirs",
     "prompt_toolkit",
 ]
 

--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import appdirs
 import ast
 from   functools                import cached_property, total_ordering
 import hashlib
@@ -14,6 +13,7 @@ import json
 import os
 import pathlib
 import pkgutil
+import platformdirs
 import textwrap
 
 from   pyflyby._fast_iter_modules \
@@ -45,7 +45,7 @@ def rebuild_import_cache():
     The cache is deleted before calling _fast_iter_modules, which repopulates the cache.
     """
     for path in pathlib.Path(
-        appdirs.user_cache_dir(appname='pyflyby', appauthor=False)
+        platformdirs.user_cache_dir(appname='pyflyby', appauthor=False)
     ).iterdir():
         _remove_import_cache_dir(path)
     _fast_iter_modules()
@@ -596,7 +596,7 @@ def _cached_module_finder(
         package or not)
     """
     cache_dir = pathlib.Path(
-        appdirs.user_cache_dir(appname='pyflyby', appauthor=False)
+        platformdirs.user_cache_dir(appname='pyflyby', appauthor=False)
     ) / hashlib.sha256(str(importer.path).encode()).hexdigest()
     cache_file = cache_dir / str(os.stat(importer.path).st_mtime_ns)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     'prompt_toolkit',
     'epydoc',
     'wheel', # required by epydoc, but not listed as a dependency
-    'appdirs',
+    'platformdirs',
 ]
 [project.urls]
 Homepage = "https://pypi.org/project/pyflyby/"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -3,22 +3,20 @@
 # License for THIS FILE ONLY: CC0 Public Domain Dedication
 # http://creativecommons.org/publicdomain/zero/1.0/
 
-
-
-
-from unittest import mock
-import pathlib
 import hashlib
 import logging.handlers
+import pathlib
+from   pkgutil                  import iter_modules
 from   pyflyby._file            import Filename
 from   pyflyby._idents          import DottedIdentifier
 from   pyflyby._log             import logger
-from   pyflyby._modules         import ModuleHandle, _fast_iter_modules, _iter_file_finder_modules
-from   pkgutil                  import iter_modules
+from   pyflyby._modules         import (ModuleHandle, _fast_iter_modules,
+                                        _iter_file_finder_modules)
 import re
 import subprocess
 import sys
 from   textwrap                 import dedent
+from   unittest                 import mock
 
 import pytest
 
@@ -125,7 +123,7 @@ def test_fast_iter_modules():
     assert fast == slow
 
 
-@mock.patch("appdirs.user_cache_dir")
+@mock.patch("platformdirs.user_cache_dir")
 def test_import_cache(mock_user_cache_dir, tmp_path):
     """Test that the import cache is built when iterating modules.
 


### PR DESCRIPTION
This PR replaces the deprecated `appdirs` dependency with `platformdirs`, a drop-in replacement.

Closes #407.