### PR TITLE
Fix broken autoimports of invalid names from IPython 9.4->9.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         # Include build dependencies for run time; see
         # https://mesonbuild.com/meson-python/how-to-guides/editable-installs.html#build-dependencies
         # for details.
-        pip install meson-python meson ninja pybind11>=2.10.4
+        pip install meson-python meson ninja "pybind11>=2.10.4"
         pip install setuptools wheel # needed for epydoc
         pip install --no-build-isolation -ve . --group lint
     - name: Mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
       # json report can't be installed on Py2, and make macos super slow.
       run: |
         python -m pytest -v --cov=pyflyby --cov-report=xml --doctest-modules --maxfail=3 lib tests
+    - uses: mxschmitt/action-tmate@v3
     - name: pytest (not MacOS)
       if: ${{ matrix.os != 'macos-latest'  }}
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,9 @@ jobs:
         # Include build dependencies for run time; see
         # https://mesonbuild.com/meson-python/how-to-guides/editable-installs.html#build-dependencies
         # for details.
-        pip install meson-python meson ninja pybind11>=2.10.4
+        pip install meson-python meson ninja "pybind11>=2.10.4"
         pip install setuptools wheel # needed for epydoc
-        pip install --no-build-isolation -ve .[test]
+        pip install --no-build-isolation -ve ".[test]"
     - name: test release build
       run: |
         python -m build
@@ -54,13 +54,12 @@ jobs:
     - name: pytest (not MacOS)
       if: ${{ matrix.os != 'macos-latest'  }}
       run: |
-        pytest -v --maxfail=3 tests/test_interactive.py::test_timeit_complete_autoimport_member_1
-        # python -m pytest -v --cov=pyflyby --cov-report=xml\
-        #        --doctest-modules\
-        #        --maxfail=3\
-        #        --json-report\
-        #        --json-report-file=report-${ENVNAME}.json\
-        #        lib tests
+        python -m pytest -v --cov=pyflyby --cov-report=xml\
+               --doctest-modules\
+               --maxfail=3\
+               --json-report\
+               --json-report-file=report-${ENVNAME}.json\
+               lib tests
     - uses: actions/upload-artifact@v4
       name: upload pytest timing reports as json
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
       # json report can't be installed on Py2, and make macos super slow.
       run: |
         python -m pytest -v --cov=pyflyby --cov-report=xml --doctest-modules --maxfail=3 lib tests
-    - uses: mxschmitt/action-tmate@v3
     - name: pytest (not MacOS)
       if: ${{ matrix.os != 'macos-latest'  }}
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,12 +53,13 @@ jobs:
     - name: pytest (not MacOS)
       if: ${{ matrix.os != 'macos-latest'  }}
       run: |
-        python -m pytest -v --cov=pyflyby --cov-report=xml\
-               --doctest-modules\
-               --maxfail=3\
-               --json-report\
-               --json-report-file=report-${ENVNAME}.json\
-               lib tests
+        pytest -v --maxfail=3 tests/test_interactive.py::test_timeit_complete_autoimport_member_1
+        # python -m pytest -v --cov=pyflyby --cov-report=xml\
+        #        --doctest-modules\
+        #        --maxfail=3\
+        #        --json-report\
+        #        --json-report-file=report-${ENVNAME}.json\
+        #        lib tests
     - uses: actions/upload-artifact@v4
       name: upload pytest timing reports as json
       with:

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -718,7 +718,7 @@ def _auto_import_hook(name: str):
         db = ImportDB.interpret_arg(None, target_filename='.')
         did_auto_import = auto_import_symbol(name, namespaces, db)
     except Exception as e:
-        logger.debug("_auto_import_hook preparation error: %r", e)
+        logger.critical("_auto_import_hook preparation error: %r", e)
         raise e
     if not did_auto_import:
         raise ImportError(f"{name} not auto-imported")
@@ -726,7 +726,7 @@ def _auto_import_hook(name: str):
         # relies on `auto_import_symbol` auto-importing into [-1] namespace
         return namespaces[-1][name]
     except Exception as e:
-        logger.debug("_auto_import_hook internal error: %r", e)
+        logger.critical("_auto_import_hook internal error: %r", e)
         raise e
 
 
@@ -1698,7 +1698,7 @@ class AutoImporter:
         #   * global_namespace - for completion of modules before they get imported
         #     (in the `global_matches` context only)
         #   * auto_import_method - for auto-import
-        logger.debug("_enable_completer_hooks(%r)", completer)
+        logger.critical("_enable_completer_hooks(%r)", completer)
 
         if hasattr(completer, "policy_overrides"):
             # `policy_overrides` and `auto_import_method` were added in IPython 9.3

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -711,7 +711,7 @@ class NamespaceWithPotentialImports(dict):
 
 
 def _auto_import_hook(name: str):
-    logger.debug("_auto_import_hook(%r)", name)
+    logger.critical("_auto_import_hook(%r)", name)
     ip = _get_ipython_app().shell
     try:
         namespaces = ScopeStack(get_global_namespaces(ip))

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -932,8 +932,8 @@ def _interact_ipython(child, input, exitstr=b"exit()\n",
                 break
         while line:
             left, tab, right = line.partition(b"\t")
-            if DEBUG:
-                print("_interact_ipython(): line=%r, left=%r, tab=%r, right=%r" % (line, left, tab, right))
+            # if DEBUG:
+            #     print("_interact_ipython(): line=%r, left=%r, tab=%r, right=%r" % (line, left, tab, right))
             # Send the input (up to tab or newline).
             child.send(left)
             # Check that the client IPython gets the input.
@@ -2972,6 +2972,7 @@ def test_timeit_complete_menu_1(frontend):
 
 @pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @pytest.mark.skipif(_IPYTHON_VERSION < (8, 27), reason='Multi-option tests are written for IPython 8.27+')
+@retry
 def test_timeit_complete_autoimport_member_1(frontend):
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -73,21 +73,19 @@ def test_failing():
     assert False
 
 
-def pytest_generate_tests(metafunc):
+@pytest.fixture
+def frontend():
     # IPython 4 and earlier only had readline frontend.
     # IPython 5.0 through 5.3 only allow prompt_toolkit.
     # IPython 5.4 through 6.5 defaults to prompt_toolkit, but allows choosing readline.
     # IPython 7+ breaks rlipython (https://github.com/ipython/rlipython/issues/21).
-    if 'frontend' in metafunc.fixturenames:
-        if _IPYTHON_VERSION >= (7,0):
-            metafunc.parametrize('frontend', [            'prompt_toolkit'])
-        else:
-            raise ImportError("IPython < 8 is unsupported.")
+    return "prompt_toolkit"
 
 
 @pytest.fixture
 def tmp(request):
     return _TmpFixture(request)
+
 
 class _TmpFixture(object):
     def __init__(self, request):
@@ -934,8 +932,8 @@ def _interact_ipython(child, input, exitstr=b"exit()\n",
                 break
         while line:
             left, tab, right = line.partition(b"\t")
-            # if DEBUG:
-            #     print("_interact_ipython(): line=%r, left=%r, tab=%r, right=%r" % (line, left, tab, right))
+            if DEBUG:
+                print("_interact_ipython(): line=%r, left=%r, tab=%r, right=%r" % (line, left, tab, right))
             # Send the input (up to tab or newline).
             child.send(left)
             # Check that the client IPython gets the input.

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -2972,7 +2972,6 @@ def test_timeit_complete_menu_1(frontend):
 
 @pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
 @pytest.mark.skipif(_IPYTHON_VERSION < (8, 27), reason='Multi-option tests are written for IPython 8.27+')
-@retry
 def test_timeit_complete_autoimport_member_1(frontend):
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()


### PR DESCRIPTION
A recent change from IPython 9.4->9.5 (https://github.com/ipython/ipython/pull/14943) made it so that invalid autoimported names were no longer attempting to be "trimmed" and reimported. I don't have the context around https://github.com/ipython/ipython/pull/14943 to know what this was for, but failed autoimports need to either raise a `SyntaxError` or a `TypeError` in order for IPython to attempt to trim and reimport it. As an example of what this looks, if the user tries to autocomplete

```python
In[1]: timeit -n 2 -r 1 base64.b64\t
```

`pyflyby._interactive._auto_import_hook` will be called with `"r1base64"` as the name to be imported (???). I'm not sure how this works, but apparently the `timeit` parameter gets smushed together and prepended to the module name, without the dash (?????). If a `SyntaxError` gets raised here, IPython will try to trim leading characters off this string until it becomes something that can be imported. So after a few tries, `"r1base64" -> "base64"` and the module gets autoimported :shrug: 

This PR changes the exception raised from a failed autoimport to a SyntaxError, fixing the `tests/test_interactive.py::test_timeit_complete_autoimport_member_1` currently failing on `master`.

## Other changes

- The autoparametrized `frontend` fixture is removed, because ipython now only supports the prompt toolkit frontend
- The pybind11 dependency in the workflows is now quoted so that shells correctly handle the version spec