### PR TITLE
Fix README rendering on PyPI by removing Sphinx-only :kbd: role

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -252,7 +252,7 @@ Other IPython magic commands work as well::
 
 .. warning::
 
-    Auto-import on :kbd:`Tab` completion requires IPython 9.3 or newer.
+    Auto-import on ``Tab`` completion requires IPython 9.3 or newer.
 
 
 Implementation details


### PR DESCRIPTION
This PR updates the README to remove the `:kbd:` interpreted text role, which is a Sphinx-specific extension not supported by PyPI's docutils renderer.