### PR TITLE
Fast module iter: use try/except

### DIFF
--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -595,6 +595,12 @@ def _cached_module_finder(
         Tuples containing (prefix+module name, a bool indicating whether the module is a
         package or not)
     """
+    if os.environ.get("PYFLYBY_DISABLE_CACHE", "0") == "1":
+        modules = _iter_file_finder_modules(importer, SUFFIXES)
+        for module, ispkg in modules:
+            yield prefix + module, ispkg
+        return
+
     cache_dir = pathlib.Path(
         platformdirs.user_cache_dir(appname='pyflyby', appauthor=False)
     ) / hashlib.sha256(str(importer.path).encode()).hexdigest()

--- a/src/_fast_iter_modules.cpp
+++ b/src/_fast_iter_modules.cpp
@@ -62,51 +62,35 @@ _iter_file_finder_modules(
     return ret;
   }
 
-  // Check if the directory is readable by examining its permissions.
-  // We use the overload of fs::status that takes an error_code to avoid throwing exceptions
-  // if the status itself cannot be retrieved (e.g., due to permissions).
-  std::error_code ec;
-  fs::file_status s = fs::status(path, ec);
-
-  if (ec) {
-    // If we couldn't get the status (e.g., due to permissions or other system errors),
-    // we treat the path as unreadable/inaccessible and skip it.
-    return ret;
-  }
-
-  // Check if any read permission bit is set for the owner, group, or others.
-  // This is a common heuristic to determine if a directory is "readable" for iteration.
-  fs::perms p = s.permissions();
-  if (!((p & fs::perms::owner_read) != fs::perms::none ||
-        (p & fs::perms::group_read) != fs::perms::none ||
-        (p & fs::perms::others_read) != fs::perms::none)) {
-    // The directory exists but no read permission is explicitly set, so we skip it.
-    return ret;
-  }
-
-  // If the directory is deemed readable based on permissions, proceed with iteration.
-  // Note: While we've checked permissions, fs::directory_iterator might still throw
-  // in rare cases (e.g., if the directory is removed concurrently or other non-permission
-  // related OS errors occur). However, this addresses the specific "permissions 000" case
-  // without using a try/catch block around the iterator itself.
-  for (auto const &entry : fs::directory_iterator(path)) {
-    fs::path entry_path = entry.path();
-    fs::path filename = entry_path.filename();
-    std::string modname = getmodulename(filename, suffixes);
+  // Attempt to iterate the directory. If the directory is unreadable for any reason
+  // (e.g., permissions, non-existent, or other system errors), fs::directory_iterator
+  // will throw a filesystem_error. We catch this and return an empty list for this path.
+  try {
+    for (auto const &entry : fs::directory_iterator(path)) {
+      fs::path entry_path = entry.path();
+      fs::path filename = entry_path.filename();
+      std::string modname = getmodulename(filename, suffixes);
 
 
-    if (modname == "" && fs::is_directory(entry_path) &&
-        filename.string().find(".") == std::string::npos &&
-        fs::is_regular_file(entry_path / "__init__.py") // Is this a package?
-    ) {
-      ret.push_back(std::make_tuple(filename.string(), true));
-    } else if (modname == "__init__") {
-      continue;
-    } else if (modname != "" && modname.find(".") == std::string::npos) {
-      ret.push_back(std::make_tuple(modname,
-                                    false // This is definitely not a package
-                                    ));
+      if (modname == "" && fs::is_directory(entry_path) &&
+          filename.string().find(".") == std::string::npos &&
+          fs::is_regular_file(entry_path / "__init__.py") // Is this a package?
+      ) {
+        ret.push_back(std::make_tuple(filename.string(), true));
+      } else if (modname == "__init__") {
+        continue;
+      } else if (modname != "" && modname.find(".") == std::string::npos) {
+        ret.push_back(std::make_tuple(modname,
+                                      false // This is definitely not a package
+                                      ));
+      }
     }
+  } catch (const fs::filesystem_error& e) {
+    // If an error occurs during directory iteration (e.g., permissions denied,
+    // directory removed concurrently), we treat it as unreadable/inaccessible
+    // and return the current (potentially empty) list, effectively skipping this path.
+    // We could log the error 'e.what()' here if desired for debugging.
+    return ret;
   }
 
   return ret;


### PR DESCRIPTION
This uses a try/except approach instead of a permission checking to catch various problems that could arise preventing reading dirs. It also adds a test.

I'm not sure how to properly test in a reliable
way when the process group is not the owner, at least on CI.

Locally:
```
$ pip install numpy
$ mkdir -p ./tmp/resricted
$ chmod 700 ./tmp/restricted
$ sudo -u nobody PYFLYBY_DISABLE_CACHE="1" PYFLYBY_SUPPRESS_CACHE_REBUILD_LOGS="1" PYTHONPATH="./tmp/restricted:$PYTHONPATH" py
In: [1]: import num<tab>
```
And check the importer is not disabled.