### PR TITLE
Add a pyflyby.check_parse subcommand, run it and fix some parsing issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
       run: |
         python -We:invalid -m compileall -f -q lib/ etc/;
 
+    - name: check-parse pyflyby
+      run: |
+        python -m pyflyby.check_parse lib/python/pyflyby
+
     - name: pytest Mac OS
       if: ${{ matrix.os == 'macos-latest'}}
       # json report can't be installed on Py2, and make macos super slow.

--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -299,7 +299,12 @@ class FilePos(object):
           `FilePos`
         '''
         ldelta, cdelta = self._intint(delta)
-        assert ldelta >= 0 and cdelta >= 0
+        # Invalid position delta: this is known to be triggerd
+        # by decorators with whitespace after @ (e.g., '@ foo'),
+        # which is valid Python syntax but not currently supported by pyflyby.
+        # a knownfail test for this case exists.
+        assert ldelta >= 0 and cdelta >= 0, (
+        )
         if ldelta == 0:
             return FilePos(self.lineno, self.colno + cdelta)
         else:

--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -303,8 +303,7 @@ class FilePos(object):
         # by decorators with whitespace after @ (e.g., '@ foo'),
         # which is valid Python syntax but not currently supported by pyflyby.
         # a knownfail test for this case exists.
-        assert ldelta >= 0 and cdelta >= 0, (
-        )
+        assert ldelta >= 0 and cdelta >= 0
         if ldelta == 0:
             return FilePos(self.lineno, self.colno + cdelta)
         else:

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -1,6 +1,19 @@
 # pyflyby/_parse.py.
 # Copyright (C) 2011, 2012, 2013, 2014, 2015, 2018 Karl Chen.
 # License: MIT http://opensource.org/licenses/MIT
+"""
+Python parsing utilities for pyflyby.
+
+This module provides AST parsing and manipulation functionality. It includes
+PythonBlock and PythonStatement classes for working with Python code.
+
+On newer versions of Python it is suggested to run
+
+    python -m pyflyby.check_parse <path/to/cpython>
+
+This will parse all Python files in the given path and report any parsing issues
+"""
+
 from __future__ import annotations, print_function
 
 import ast
@@ -176,10 +189,10 @@ def _iter_child_nodes_in_order_internal_1(node):
             res = (
                 node.type_comment,
                 node.decorator_list,
+                node.type_params,
                 node.args,
                 node.returns,
                 node.body,
-                node.type_params
             )
             yield res
 
@@ -206,7 +219,7 @@ def _iter_child_nodes_in_order_internal_1(node):
     elif isinstance(node, ast.ClassDef):
         if sys.version_info > (3, 12):
             assert node._fields == ('name', 'bases', 'keywords', 'body', 'decorator_list', 'type_params'), node._fields
-            yield node.decorator_list, node.bases, node.body, node.type_params
+            yield node.decorator_list, node.type_params, node.bases, node.body
         else:
             assert node._fields == ('name', 'bases', 'keywords', 'body', 'decorator_list'), node._fields
             yield node.decorator_list, node.bases, node.body
@@ -449,11 +462,14 @@ def _annotate_ast_startpos(
                         for cn in _iter_child_nodes_in_order(aast_node)
                     )
                     + "\n"
-                    "This indicates a bug in pyflyby._\n"
+                    "This indicates a bug in pyflyby._parse\n"
                     "\n"
                     "pyflyby developer: Check if there's a bug or missing ast node handler in "
                     "pyflyby._parse._iter_child_nodes_in_order() - "
-                    "probably the handler for ast.%s." % type(aast_node).__name__
+                    +"probably the handler for ast.%s." % type(aast_node).__name__
+                    +"\n"
+                    "Please also run python -m pyflyby.check_parse on the cpython source tree"
+                    "to test for new syntax."
                 )
             child_minpos = child_node.startpos
         is_first_child = False

--- a/lib/python/pyflyby/check_parse.py
+++ b/lib/python/pyflyby/check_parse.py
@@ -1,0 +1,171 @@
+# pyflyby/check_parse.py
+"""
+Module to parse all Python files in a given path using PythonBlock to detect parsing issues.
+
+This is specifically useful for catching bugs in pyflyby's _parse.py
+implementation by scanning large codebase, typically `cpython`, or linters that
+usually have many usefull testcases like `ruff`
+
+Usage:
+    python -m pyflyby.check_parse <path>
+"""
+
+import ast
+import sys
+import warnings
+from pathlib import Path
+from typing import List, Tuple
+
+from pyflyby._parse import PythonBlock
+
+
+def find_python_files(path: Path) -> List[Path]:
+    """Find all Python files in the given path recursively.
+
+    Exclude venv ans other kind of files.
+    """
+    if path.is_file():
+        return [path] if path.suffix == ".py" else []
+
+    python_files = []
+    for item in path.rglob("*.py"):
+        if item.is_file():
+            # Skip common directories that might have issues or be too large
+            if any(part.startswith(".") for part in item.parts):
+                continue
+            if any(part in ("__pycache__", "venv", "env") for part in item.parts):
+                continue
+            python_files.append(item)
+
+    return sorted(python_files)
+
+
+def parse_file(file_path: Path) -> Tuple[bool, str]:
+    """
+    Try to parse a Python file using PythonBlock.
+
+    Only reports errors if PythonBlock fails but ast.parse succeeds,
+    indicating a pyflyby-specific parsing issue.
+
+    Scanning CPython/Ruff can trigger many errors in ast.parse because of many
+    test cases failing on purpose.
+
+    Returns:
+        (success, error_message) tuple
+    """
+    try:
+        content = file_path.read_text()
+    except UnicodeDecodeError:
+        return True, ""
+
+    # Try parsing with ast to see if it's a valid Python file
+    ast_has_warning = False
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", SyntaxWarning)
+            ast.parse(content, filename=file_path, type_comments=True)
+    except SyntaxError:
+        return True, ""
+    except SyntaxWarning:
+        ast_has_warning = True
+
+    # Now try parsing with PythonBlock
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", SyntaxWarning)
+            block = PythonBlock(content, auto_flags=True)
+
+            # Access the annotated_ast_node to ensure it's created without errors
+            _ = block.annotated_ast_node
+
+    except SyntaxWarning as e:
+        # If ast also had a warning, it's not pyflyby-specific
+        if ast_has_warning:
+            return True, ""
+        return False, f"SyntaxWarning: {e}"
+    except SyntaxError as e:
+        return False, f"SyntaxError: {e}"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+    return True, ""
+
+
+def check_parse_main():
+    """Main entry point for check-parse command.
+
+    Returns:
+        0 on success, error message string on failure
+    """
+    if len(sys.argv) != 2:
+        return """Usage: python -m pyflyby.check_parse <path>
+
+Parse all Python files in the given path using PythonBlock to detect
+pyflyby-specific parsing issues. This compares pyflyby's parser against
+the standard library's ast.parse() to identify bugs in pyflyby's _parse.py.
+
+Only reports errors that occur with pyflyby but not with ast.parse,
+indicating pyflyby-specific bugs rather than legitimate Python syntax errors.
+"""
+
+    path = Path(sys.argv[1]).resolve()
+
+    print(f"Searching for Python files in: {path}")
+    python_files = find_python_files(path)
+
+    if not python_files:
+        return "No Python files found"
+
+    print(f"Found {len(python_files)} Python file(s)")
+
+    failed_files = []
+    success_count = 0
+    total = len(python_files)
+    is_tty = sys.stdout.isatty()
+    last_printed_progress = -1
+
+    for i, file_path in enumerate(python_files, 1):
+        progress = i * 100 // total
+
+        if is_tty:
+            # Display progress bar with fancy ASCII blocks
+            bar_length = 40
+            filled = bar_length * i // total
+            bar = "█" * filled + "░" * (bar_length - filled)
+            print(f"\rParsing: {bar} {i}/{total} ({progress}%)", end="", flush=True)
+        else:
+            # Print every 5% when not a TTY
+            if progress >= last_printed_progress + 5:
+                print(f"Progress: {progress}% ({i}/{total})")
+                last_printed_progress = progress
+
+        success, error = parse_file(file_path)
+
+        if success:
+            success_count += 1
+        else:
+            # Clear progress bar and print error
+            if is_tty:
+                print(f"\r{' ' * 80}\r", end="")
+            print(f"✗ {file_path}")
+            print(f"  {error}")
+            failed_files.append((file_path, error))
+
+    # Clear progress bar
+    if is_tty:
+        print(f"\r{' ' * 80}\r", end="")
+
+    print(f"Results: {success_count}/{total} files parsed successfully")
+
+    if failed_files:
+        error_msg = f"\n{len(failed_files)} file(s) failed:\n"
+        for file_path, error in failed_files:
+            error_msg += f"  - {file_path}\n"
+            error_msg += f"    {error}\n"
+        return error_msg
+    print("✓ All files parsed successfully!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check_parse_main())

--- a/lib/python/pyflyby/meson.build
+++ b/lib/python/pyflyby/meson.build
@@ -21,6 +21,7 @@ py.install_sources(
     '_log.py',
     '_modules.py',
     '_parse.py',
+    'check_parse.py',
     '_py.py',
     '_saveframe.py',
     '_saveframe_reader.py',


### PR DESCRIPTION
Implements a new check_parse subcommand that compares pyflyby's parser against ast.parse() to detect pyflyby-specific bugs. This helps identify issues like incorrect AST node ordering, f-string handling, and other parsing edge cases.

After running check_parse on CPython source (as of 3.15-dev), this founds a couple of issues, for which tests and fixes were added.

Note that some of `ruff` test cases in particular some that have spaces after `@` in decorator are failing, have been added and marked as known-fail. A fix is possible, but likelynot worth it.

check_parse is also being run on pyflyby itself in CI.