### PR TITLE
Drop six requirement

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -23,7 +23,6 @@ from   pyflyby._modules         import ModuleHandle
 from   pyflyby._parse           import (MatchAs, PythonBlock, _is_ast_str,
                                         infer_compile_mode)
 
-from   six                      import reraise
 import sys
 import types
 from   typing                   import (Any, Dict, List, Optional, Set, Tuple,
@@ -2220,7 +2219,7 @@ def load_symbol(fullname, namespaces, autoimport=False, db=None,
                 except Exception as e:
                     e2 = LoadSymbolError(fullname)
                     e2.__cause__ = e
-                    reraise(LoadSymbolError, e2, sys.exc_info()[2])
+                    raise e2
             return obj
     else:
         # Not found in any namespace.

--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -26,7 +26,6 @@ from   pyflyby._util            import (ExcludeImplicitCwdFromPathCtx, cmp,
 
 import re
 import shutil
-from   six                      import reraise
 import sys
 import types
 from   typing                   import Any, Dict, Generator, Union
@@ -113,13 +112,13 @@ def import_module(module_name):
                      real_importerror1, real_importerror2, real_importerror3)
         if real_importerror1 and real_importerror2 and real_importerror3:
             raise
-        reraise(ErrorDuringImportError, ErrorDuringImportError(
+        raise ErrorDuringImportError(
             "Error while attempting to import %s: %s: %s"
-            % (module_name, type(e).__name__, e)), sys.exc_info()[2])
+            % (module_name, type(e).__name__, e)) from e
     except Exception as e:
-        reraise(ErrorDuringImportError, ErrorDuringImportError(
+        raise ErrorDuringImportError(
             "Error while attempting to import %s: %s: %s"
-            % (module_name, type(e).__name__, e)), sys.exc_info()[2])
+            % (module_name, type(e).__name__, e)) from e
 
 
 def _my_iter_modules(path, prefix=''):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 ]
 dependencies = [
     "black",
-    "six",
     "tomli; python_version<'3.11'",
     "typing_extensions>=4.6; python_version<'3.12'",
     'prompt_toolkit',
@@ -66,7 +65,6 @@ lint = [
     'flake8',
     'mypy',
     'pyflakes',
-    'types-six',
 ]
 docs = [
     'sphinx',


### PR DESCRIPTION
Pyflyby have been py3only for wuite some time.

I did not remove the six import isn etc/pyflyby/std.py database