### PR TITLE
Add delayed type annotation test & fix self-import

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -1014,19 +1014,26 @@ class _MissingImportFinder:
         scope[fullname] = value
 
     def _remove_from_missing_imports(self, fullname):
-        for missing_import in self.missing_imports:
+        for missing_import in list(self.missing_imports):
             # If it was defined inside a class method, then it wouldn't have been added to
             # the missing imports anyways (except in that case of annotations)
             # See the following tests:
             # - tests.test_autoimp.test_method_reference_current_class
             # - tests.test_autoimp.test_find_missing_imports_class_name_1
             # - tests.test_autoimp.test_scan_for_import_issues_class_defined_after_use
-            scopestack = missing_import[1].scope_info['scopestack']
+            missing_ident = missing_import[1]
+            if not missing_ident.startswith(fullname):
+                continue
+            scopestack = missing_ident.scope_info['scopestack']
             in_class_scope = isinstance(scopestack[-1], _ClassScope)
-            inside_class = missing_import[1].scope_info.get('_in_class_def')
-            if missing_import[1].startswith(fullname):
-                if in_class_scope or not inside_class:
-                    self.missing_imports.remove(missing_import)
+            inside_class = missing_ident.scope_info.get('_in_class_def')
+            # Remove if it's in class scope or not inside a class definition
+            # Also remove if it's a simple identifier (forward reference in type annotation)
+            # that matches the class name, regardless of scope
+            is_simple_identifier = (len(missing_ident.parts) == 1 and
+                                    missing_ident.parts[0] == fullname)
+            if in_class_scope or not inside_class or is_simple_identifier:
+                self.missing_imports.remove(missing_import)
 
     def _get_scope_info(self):
         return {

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -1769,6 +1769,31 @@ def test_scan_for_import_issues_class_defined_after_use():
     assert unused == []
 
 
+def test_scan_for_import_issues_class_in_type_annotation_before_definition():
+    """
+    Test that a class used in function parameter type annotations before
+    it's defined is not reported as missing.
+
+    This test would have failed before the fix in _remove_from_missing_imports
+    that handles simple identifiers in type annotations.
+    """
+    code = dedent("""
+    class PythonStatement:
+        block: "PythonBlock"
+
+        def from_block(cls, block: PythonBlock) -> PythonStatement:
+            pass
+
+    class PythonBlock:
+        pass
+    """)
+    missing, unused = scan_for_import_issues(code)
+    # PythonBlock should not be reported as missing even though it's used
+    # in type annotations before it's defined
+    assert missing == [], f"Expected no missing imports, got {missing}"
+    assert unused == []
+
+
 def test_setattr_is_not_unused():
     code = dedent("""
         from a import b


### PR DESCRIPTION
Add delayed type annotation test.

Add a test that missing imports are properly detected when they are from
later defined class definition.

This prevens running tidy-import on pyflyby itself as it adds a
PythonBlock import from itself to _parse.py


WE then fix it by making sure when we encounter a new class, remove the matching missing import name,