### PR TITLE
Fix `# tidy-imports: ignore-import` not working on long lines.

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -1063,11 +1063,13 @@ class _MissingImportFinder:
             # Handle leading prefixes so we don't think they're unused
             for prefix in DottedIdentifier(node.name).prefixes[:-1]:
                 self._visit_Store(str(prefix), None)
-        alias_lineno = getattr(node, "lineno", None)
+        # Only honour pragmas on the alias's own line(s).  Scanning the whole
+        # parent ``ImportFrom`` range would over-protect siblings in a
+        # parenthesized ``from x import (a, b)`` group when only one alias is
+        # annotated.
+        alias_lineno = getattr(node, "lineno", self._lineno)
         alias_end_lineno = getattr(node, "end_lineno", alias_lineno)
         ignore_pragma = _has_ignore_pragma(
-            self._source_lines, self._lineno, alias_end_lineno
-        ) or _has_ignore_pragma(
             self._source_lines, alias_lineno, alias_end_lineno
         )
         if is_star or modulename == "__future__" or not self.find_unused_imports or ignore_pragma:

--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -1063,7 +1063,14 @@ class _MissingImportFinder:
             # Handle leading prefixes so we don't think they're unused
             for prefix in DottedIdentifier(node.name).prefixes[:-1]:
                 self._visit_Store(str(prefix), None)
-        if is_star or modulename == "__future__" or not self.find_unused_imports or _has_ignore_pragma(self._source_lines, self._lineno):
+        alias_lineno = getattr(node, "lineno", None)
+        alias_end_lineno = getattr(node, "end_lineno", alias_lineno)
+        ignore_pragma = _has_ignore_pragma(
+            self._source_lines, self._lineno, alias_end_lineno
+        ) or _has_ignore_pragma(
+            self._source_lines, alias_lineno, alias_end_lineno
+        )
+        if is_star or modulename == "__future__" or not self.find_unused_imports or ignore_pragma:
             value = None
         else:
             imp = Import.from_split((modulename, node.name, name))

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -396,7 +396,9 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
             group_no_ignore_pragma = [
                 node
                 for node in group
-                if not _has_ignore_pragma(lines, node.lineno)
+                if not _has_ignore_pragma(
+                    lines, node.lineno, getattr(node, "end_lineno", node.lineno)
+                )
             ]
             if not group_no_ignore_pragma:
                 continue

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -579,14 +579,12 @@ class ImportStatement:
         """
         Pretty-print into a single string.
 
-        ImportStatement objects represent python import statements, which can span
-        multiple lines or multiple aliases. Here we append comments
-
-        - If the output is one line
-        - If there is only one comment
-
-        This way we avoid worrying about combining comments from multiple lines,
-        or where to place comments if the resulting output is more than one line
+        ImportStatement objects represent python import statements, which can
+        span multiple lines or multiple aliases.  When the statement has a
+        single, unambiguous trailing comment (see ``get_valid_comment``), it is
+        appended to the last rendered line so that pragmas like
+        ``# tidy-imports: ignore-import`` survive reformatting even when the
+        import wraps onto a backslash continuation.
 
         :type params:
           `FormatParams`
@@ -625,16 +623,11 @@ class ImportStatement:
 
         comment = self.get_valid_comment()
         if comment is not None:
-            # Append to the last non-empty line so the comment is preserved
-            # even when the import wraps onto a backslash-continued line
-            # (e.g. ``from very.long.module \\\n    import x``).
-            lines = res.split('\n')
-            last_idx = len(lines) - 1
-            while last_idx >= 0 and not lines[last_idx].strip():
-                last_idx -= 1
-            if last_idx >= 0:
-                lines[last_idx] += f" #{comment}"
-                res = "\n".join(lines)
+            # ``pyfill`` always terminates with exactly one '\n'; splice the
+            # comment in just before it so it lands on the last rendered line
+            # (which, for a wrapped import, is the ``import x`` continuation).
+            assert res.endswith("\n")
+            res = res[:-1] + f" #{comment}\n"
 
         if params.use_black:
             res = self.run_black(res, params)

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -625,10 +625,15 @@ class ImportStatement:
 
         comment = self.get_valid_comment()
         if comment is not None:
-            # Only append to text on the first line
+            # Append to the last non-empty line so the comment is preserved
+            # even when the import wraps onto a backslash-continued line
+            # (e.g. ``from very.long.module \\\n    import x``).
             lines = res.split('\n')
-            if len(lines) == 2:
-                lines[0] += f" #{comment}"
+            last_idx = len(lines) - 1
+            while last_idx >= 0 and not lines[last_idx].strip():
+                last_idx -= 1
+            if last_idx >= 0:
+                lines[last_idx] += f" #{comment}"
                 res = "\n".join(lines)
 
         if params.use_black:

--- a/lib/python/pyflyby/_util.py
+++ b/lib/python/pyflyby/_util.py
@@ -35,7 +35,7 @@ def _has_ignore_pragma(
     """
     if lines is None or lineno is None:
         return False
-    if end_lineno is None or end_lineno < lineno:
+    if end_lineno is None:
         end_lineno = lineno
     for ln in range(lineno, end_lineno + 1):
         idx = ln - 1

--- a/lib/python/pyflyby/_util.py
+++ b/lib/python/pyflyby/_util.py
@@ -20,14 +20,28 @@ from   functools                import (cache as memoize,
 __all__ = ["cached_attribute", "memoize"]
 
 
-def _has_ignore_pragma(lines: list[str] | None, lineno: int | None) -> bool:
-    """Check if the given line has a ``# tidy-imports: ignore-import`` pragma."""
+def _has_ignore_pragma(
+    lines: "list[str] | None",
+    lineno: "int | None",
+    end_lineno: "int | None" = None,
+) -> bool:
+    """Check if any line in ``[lineno, end_lineno]`` has a
+    ``# tidy-imports: ignore-import`` pragma.
+
+    A backslash-continued or parenthesized import may span several lines, and
+    the pragma comment can appear on any of them (most commonly on the line
+    that actually contains the imported name).  When ``end_lineno`` is omitted
+    only ``lineno`` is checked.
+    """
     if lines is None or lineno is None:
         return False
-    idx = lineno - 1
-    if not (0 <= idx < len(lines)):
-        return False
-    return "# tidy-imports: ignore-import" in lines[idx]
+    if end_lineno is None or end_lineno < lineno:
+        end_lineno = lineno
+    for ln in range(lineno, end_lineno + 1):
+        idx = ln - 1
+        if 0 <= idx < len(lines) and "# tidy-imports: ignore-import" in lines[idx]:
+            return True
+    return False
 
 
 class WrappedAttributeError(Exception):

--- a/tests/test_imports2s_bis.py
+++ b/tests/test_imports2s_bis.py
@@ -462,6 +462,27 @@ class MyClass:
             [],
             id="pragma_local_class_method",
         ),
+        pytest.param(
+            """\
+from foo.bar import baz  # tidy-imports: ignore-import
+from aaaaa.bbbbb.ccccc.ddddd.eee import ggggg  # tidy-imports: ignore-import
+""",
+            False,
+            ["from foo.bar", "baz", "aaaaa.bbbbb.ccccc.ddddd.eee", "ggggg"],
+            [],
+            id="pragma_long_from_import_wraps",
+        ),
+        pytest.param(
+            """\
+def foo():
+    from aaaaa.bbbbb.ccccc.ddddd.eee import ggggg  # tidy-imports: ignore-import
+    return 42
+""",
+            True,
+            ["aaaaa.bbbbb.ccccc.ddddd.eee", "ggggg"],
+            [],
+            id="pragma_long_local_from_import",
+        ),
     ],
 )
 def test_ignore_import_pragma(

--- a/tests/test_imports2s_bis.py
+++ b/tests/test_imports2s_bis.py
@@ -483,6 +483,29 @@ def foo():
             [],
             id="pragma_long_local_from_import",
         ),
+        pytest.param(
+            """\
+from foo import (
+    kept,    # tidy-imports: ignore-import
+    dropped,
+)
+""",
+            False,
+            ["kept"],
+            ["dropped"],
+            id="pragma_paren_group_per_alias",
+            marks=pytest.mark.skip(
+                reason=(
+                    "Per-alias pragmas inside a parenthesized "
+                    "'from x import (a, b)' group are not yet honoured: "
+                    "ImportStatement.get_valid_comment() drops comments for "
+                    "multi-alias statements during the initial reformat pass, "
+                    "so the pragma is gone before _has_ignore_pragma runs. "
+                    "The alias-scoped check in _visit_StoreImport is the "
+                    "correct semantics for when that limitation is lifted."
+                ),
+            ),
+        ),
     ],
 )
 def test_ignore_import_pragma(


### PR DESCRIPTION
After a reformat the comment may ends up on a different line than the original one, and in particular on the `import` part of `from... import  ..`. properly check the full import for existance of the type comment.

Should close Quansight/deshaw#684