### PR TITLE
Keep regular imports separate from __future__ imports

### DIFF
--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -850,7 +850,10 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         sepblock_before._output = PythonBlock("\n")
         insert_at = future_block_indexes[-1] + 1
         next_block = self.blocks[insert_at] if insert_at < len(self.blocks) else None
-        blocks_to_insert: list[SourceToSourceTransformationBase] = [sepblock_before, block]
+        blocks_to_insert: list[Union[SourceToSourceImportBlockTransformation, SourceToSourceTransformation]] = [
+            sepblock_before,
+            block,
+        ]
         if not (
             isinstance(next_block, SourceToSourceTransformation)
             and str(next_block.pretty_print()).startswith("\n")

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -217,6 +217,11 @@ class ImportAlreadyExistsError(Exception):
     pass
 
 
+def _is_future_only_import_block(block: SourceToSourceImportBlockTransformation) -> bool:
+    imports = block.importset.imports
+    return bool(imports) and all(imp.split.module_name == "__future__" for imp in imports)
+
+
 def _maybe_insert_pass(
     lines: list[str], idx: int, indent: int, lineno: int
 ) -> None:
@@ -769,7 +774,11 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
               block )
             for block in self.import_blocks
             if not isinstance(block, _LocalImportBlockWrapper)
-            and block.input.endpos.lineno <= max_lineno+1 ]
+            and block.input.endpos.lineno <= max_lineno+1
+            and (
+                imp.split.module_name == "__future__"
+                or not _is_future_only_import_block(block)
+            ) ]
         if not annotated_blocks:
             raise NoImportBlockError()
         annotated_blocks.sort(key=lambda x: x[0])
@@ -826,6 +835,43 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         self.import_blocks.insert(0, block)
         return block
 
+    def insert_new_import_block_after_future_imports(self) -> SourceToSourceImportBlockTransformation:
+        future_block_indexes = [
+            idx
+            for idx, block in enumerate(self.blocks)
+            if isinstance(block, SourceToSourceImportBlockTransformation)
+            and _is_future_only_import_block(block)
+        ]
+        if not future_block_indexes:
+            return self.insert_new_import_block()
+
+        block = SourceToSourceImportBlockTransformation("")
+        sepblock_before = SourceToSourceTransformation("")
+        sepblock_before._output = PythonBlock("\n")
+        insert_at = future_block_indexes[-1] + 1
+        next_block = self.blocks[insert_at] if insert_at < len(self.blocks) else None
+        blocks_to_insert: list[SourceToSourceTransformationBase] = [sepblock_before, block]
+        if not (
+            isinstance(next_block, SourceToSourceTransformation)
+            and str(next_block.pretty_print()).startswith("\n")
+        ):
+            sepblock_after = SourceToSourceTransformation("")
+            sepblock_after._output = PythonBlock("\n")
+            blocks_to_insert.append(sepblock_after)
+
+        self.blocks[insert_at:insert_at] = blocks_to_insert
+        future_import_block_indexes = [
+            idx
+            for idx, import_block in enumerate(self.import_blocks)
+            if not isinstance(import_block, _LocalImportBlockWrapper)
+            and _is_future_only_import_block(import_block)
+        ]
+        import_block_insert_at = (
+            future_import_block_indexes[-1] + 1 if future_import_block_indexes else 0
+        )
+        self.import_blocks.insert(import_block_insert_at, block)
+        return block
+
     def add_import(self, imp: Import, lineno: Any = Inf) -> None:
         """
         Add the specified import.  Picks an existing global import block to
@@ -841,7 +887,10 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
             block = self.select_import_block_by_closest_prefix_match(
                 imp, lineno)
         except NoImportBlockError:
-            block = self.insert_new_import_block()
+            if imp.split.module_name == "__future__":
+                block = self.insert_new_import_block()
+            else:
+                block = self.insert_new_import_block_after_future_imports()
         if imp in block.importset.imports:
             raise ImportAlreadyExistsError(imp)
         block.importset = block.importset.with_imports([imp])

--- a/tests/test_imports2s.py
+++ b/tests/test_imports2s.py
@@ -129,6 +129,48 @@ def test_fix_unused_and_missing_imports_1():
     assert output == expected
 
 
+def test_mandatory_future_import_keeps_regular_imports_separate():
+    input = PythonBlock(dedent('''
+        from __future__ import absolute_import
+
+        os
+        sys
+    ''').lstrip(), filename="/foo/test_mandatory_future_import_keeps_regular_imports_separate.py")
+    db = ImportDB("""
+        import os
+        import sys
+        __mandatory_imports__ = ["from __future__ import division"]
+    """)
+    output = fix_unused_and_missing_imports(input, db=db)
+    expected = PythonBlock(dedent('''
+        from __future__ import absolute_import, division
+
+        import os
+        import sys
+
+        os
+        sys
+    ''').lstrip(), filename="/foo/test_mandatory_future_import_keeps_regular_imports_separate.py")
+    assert output == expected
+
+
+def test_missing_import_after_future_import_without_existing_separator():
+    input = PythonBlock(dedent('''
+        from __future__ import absolute_import
+        os
+    ''').lstrip(), filename="/foo/test_missing_import_after_future_import_without_existing_separator.py")
+    db = ImportDB("import os")
+    output = fix_unused_and_missing_imports(input, db=db)
+    expected = PythonBlock(dedent('''
+        from __future__ import absolute_import
+
+        import os
+
+        os
+    ''').lstrip(), filename="/foo/test_missing_import_after_future_import_without_existing_separator.py")
+    assert output == expected
+
+
 def test_fix_unused_and_missing_imports_unknown_1():
     input = PythonBlock(dedent('''
         os, sys
@@ -1084,6 +1126,7 @@ def test_future_flags_1():
     output = fix_unused_and_missing_imports(input, db=db)
     expected = PythonBlock(dedent('''
         from __future__ import print_function
+
         import sys
 
         print("", file=sys.stdout)


### PR DESCRIPTION
Fixes #24.

When `tidy-imports` adds a normal import to a file that only has a `__future__` import block, the current block-selection heuristic reuses that future-only block. After pretty-printing, the result puts regular imports immediately after `from __future__ ...`, without the required blank line.

This changes the insertion path so that:

- future imports can still merge into an existing future-only block
- regular imports skip future-only blocks when selecting a block by prefix match
- if no regular import block exists yet, a new one is inserted after the leading future block instead of before it or inside it

I added regressions for both the issue-shaped mandatory-import case and the adjacent-code case where the original file has no blank separator after the future import.

Validation:

- `python -m pip install . --no-deps`
- `python -m pip install . --no-deps --force-reinstall`
- direct API repro for #24 now prints:

```python
from __future__ import absolute_import, division

import os
import sys

os
sys
```

- `python -m pytest tests/test_imports2s.py::test_mandatory_future_import_keeps_regular_imports_separate tests/test_imports2s.py::test_missing_import_after_future_import_without_existing_separator tests/test_imports2s.py::test_fix_unused_and_missing_imports_1 tests/test_imports2s.py::test_future_flags_1 -q` (`4 passed`)
- `python -m pytest tests/test_imports2s.py -q` (`100 passed, 1 skipped, 1 xfailed`)
- `PYTHONPATH=lib/python python bin/tidy-imports -r "$tmp"` on the original file-shaped repro, after using the locally built `_fast_iter_modules` extension for the source-tree import path
- `python -m py_compile lib/python/pyflyby/_imports2s.py tests/test_imports2s.py`
