### PR TITLE
Fix unbounded growth of the module import cache

### DIFF
--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -48,35 +48,46 @@ def rebuild_import_cache() -> None:
 
     The cache is deleted before calling _fast_iter_modules, which repopulates the cache.
     """
-    for path in pathlib.Path(
+    cache_dir = pathlib.Path(
         platformdirs.user_cache_dir(appname='pyflyby', appauthor=False)
-    ).iterdir():
-        _remove_import_cache_dir(path)
+    )
+    if cache_dir.is_dir():
+        for path in cache_dir.iterdir():
+            _remove_import_cache_entry(path)
     _fast_iter_modules()
 
 
-def _remove_import_cache_dir(path: pathlib.Path) -> None:
-    """Remove an import cache directory.
+def _remove_import_cache_entry(path: pathlib.Path) -> None:
+    """Remove an entry from the pyflyby import cache.
 
-    Import cache directories exist in <user cache dir>/pyflyby/, and they should
-    contain just a single file which itself contains a JSON blob of cached import names.
-    We therefore only delete the requested path if it is a directory.
+    The cache lives under ``<user cache dir>/pyflyby/`` and has two kinds of
+    entries:
+
+    - per-importer directories, named by the sha256 of the importer path, and
+    - the ``<mtime_ns>`` cache files inside them, each holding a JSON blob of
+      cached import names.
+
+    `rebuild_import_cache` removes whole per-importer directories, while
+    `_cached_module_finder` removes stale ``<mtime_ns>`` files before writing a
+    fresh one.  Either kind may be passed here, so a directory is removed
+    recursively and a file is unlinked directly.
 
     Parameters
     ----------
     path : pathlib.Path
-        Import cache directory path to remove
+        Import cache entry (file or directory) to remove
     """
-    if path.is_dir():
-        # Only directories are valid import cache entries
-        try:
+    try:
+        if path.is_dir():
             shutil.rmtree(str(path))
-        except Exception as e:
-            logger.error(
-                f"Failed to remove cache directory at {path} - please "
-                "consider removing this directory manually. Error:\n"
-                f"{textwrap.indent(str(e), prefix='  ')}"
-            )
+        else:
+            path.unlink()
+    except Exception as e:
+        logger.error(
+            f"Failed to remove cache entry at {path} - please "
+            "consider removing this manually. Error:\n"
+            f"{textwrap.indent(str(e), prefix='  ')}"
+        )
 
 
 @memoize
@@ -127,7 +138,7 @@ def import_module(module_name: Any) -> types.ModuleType:
 
 
 def _my_iter_modules(
-    path: Any, prefix: str = ''
+    path: Optional[str], prefix: str = ''
 ) -> Generator[tuple[str, bool], None, None]:
     # Modified version of pkgutil.ImpImporter.iter_modules(), patched to
     # handle inaccessible subdirectories.
@@ -617,7 +628,7 @@ def _cached_module_finder(
         # files for the given import path
         cache_dir.mkdir(parents=True, exist_ok=True)
         for path in cache_dir.iterdir():
-            _remove_import_cache_dir(path)
+            _remove_import_cache_entry(path)
 
         if os.environ.get("PYFLYBY_SUPPRESS_CACHE_REBUILD_LOGS", "1") != "1":
             logger.info(f"Rebuilding cache for {_format_path(importer.path)}...")

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -12,7 +12,8 @@ from   pyflyby._file            import Filename
 from   pyflyby._idents          import DottedIdentifier
 from   pyflyby._log             import logger
 from   pyflyby._modules         import (ModuleHandle, _fast_iter_modules,
-                                        _iter_file_finder_modules)
+                                        _iter_file_finder_modules,
+                                        rebuild_import_cache)
 import re
 import subprocess
 import sys
@@ -198,6 +199,14 @@ def test_import_cache(mock_user_cache_dir, tmp_path):
     assert len(list(tmp_path.iterdir())) == n_cached_paths
     mock_iffm.assert_called_once()
 
+    # Regression: when the importer's mtime changes, a new <mtime_ns> cache file
+    # is written and the stale one must be removed.  Otherwise stale cache files
+    # (which are files, not dirs, inside the per-importer cache directory)
+    # accumulate without bound.  `path` here is the importer whose mtime we just
+    # bumped; its cache directory should hold exactly the one current file.
+    touched_cache_dir = tmp_path / hashlib.sha256(str(path).encode()).hexdigest()
+    assert len(list(touched_cache_dir.iterdir())) == 1
+
 @mock.patch.dict(os.environ, {"PYFLYBY_DISABLE_CACHE": "1"})
 @mock.patch("platformdirs.user_cache_dir")
 def test_import_perms(mock_user_cache_dir, tmp_path):
@@ -214,3 +223,41 @@ def test_import_perms(mock_user_cache_dir, tmp_path):
             list(_fast_iter_modules())
         finally:
             sys.path.remove(restricted)
+
+
+@mock.patch("platformdirs.user_cache_dir")
+def test_rebuild_import_cache(mock_user_cache_dir, tmp_path):
+    """rebuild_import_cache() clears existing cache directories and repopulates."""
+    mock_user_cache_dir.return_value = tmp_path
+    # Seed a stale cache directory; rebuild should remove it.
+    stale = tmp_path / "deadbeef"
+    stale.mkdir()
+    (stale / "modules.json").write_text("{}")
+    with mock.patch("pyflyby._modules._fast_iter_modules") as mock_fim:
+        rebuild_import_cache()
+    assert not stale.exists()      # stale cache dir removed
+    mock_fim.assert_called_once()  # cache repopulated
+
+
+@mock.patch("platformdirs.user_cache_dir")
+def test_rebuild_import_cache_missing_dir(mock_user_cache_dir, tmp_path):
+    """rebuild_import_cache() doesn't crash when the cache dir doesn't exist yet."""
+    mock_user_cache_dir.return_value = tmp_path / "does_not_exist"
+    with mock.patch("pyflyby._modules._fast_iter_modules") as mock_fim:
+        rebuild_import_cache()  # must not raise FileNotFoundError
+    mock_fim.assert_called_once()
+
+
+def test_submodules_oserror_fallback():
+    """When pkgutil.iter_modules raises OSError, ModuleHandle.submodules falls
+    back to _my_iter_modules, which is robust to inaccessible paths."""
+    import pkgutil
+    mh = ModuleHandle("email")
+    # submodules is a cached_property on a cached ModuleHandle; evict any
+    # previously-computed value so it recomputes under the patch below.
+    mh.__dict__.pop("submodules", None)
+    with mock.patch.object(pkgutil, "iter_modules", side_effect=OSError("boom")):
+        submodules = mh.submodules
+    names = {str(m.name) for m in submodules}
+    # email.mime is a subpackage, exercising _my_iter_modules' package branch.
+    assert "email.mime" in names


### PR DESCRIPTION
When an importer path's mtime changed, _cached_module_finder() wrote a new <mtime_ns> cache file but never removed the stale ones: it called _remove_import_cache_dir(), whose `if path.is_dir()` guard silently skipped the cache *files* (the entries inside a per-importer cache directory are mtime-named files, not directories). Stale cache files therefore accumulated without bound for any path whose mtime changed.

- Rename _remove_import_cache_dir -> _remove_import_cache_entry and have it remove either a directory (rmtree) or a file (unlink), so both call sites work: rebuild_import_cache() passes per-importer directories and _cached_module_finder() passes stale <mtime_ns> files.
- Guard rebuild_import_cache() against a missing cache directory; iterdir() previously raised FileNotFoundError on a clean system.
- Tighten _my_iter_modules() annotation: path is Optional[str], not Any.

Tests:
- Extend test_import_cache to assert exactly one <mtime_ns> file remains after an mtime change (fails as `assert 2 == 1` on the previous code).
- Add tests for rebuild_import_cache() (including the missing-dir path) and for the _my_iter_modules() OSError fallback reached via ModuleHandle.submodules.