### PR TITLE
Fix symlink=error default being ignored.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,4 +140,4 @@ jobs:
           rm /tmp/cpython/Lib/test/tokenizedata/badsyntax_3131.py
           rm /tmp/cpython/Lib/test/tokenizedata/badsyntax_pep3120.py
 
-          uv run python bin/tidy-imports --no-add --no-remove-unused --action=NOTHING /tmp/cpython >/dev/null
+          uv run python bin/tidy-imports --no-add --no-remove-unused --symlink=skip --action=NOTHING /tmp/cpython >/dev/null

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -61,6 +61,42 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
     # casts (runtime changes), which are out of scope for a type-only pass.
     """
     Do setup for a top-level script and parse arguments.
+
+    Performs common setup for pyflyby command-line tools: installs a SIGPIPE
+    handler, builds an `optparse.OptionParser`, registers the standard options
+    (``--debug``, ``--verbose``, ``--quiet``, ``--version``), optionally adds
+    groups of action and/or pretty-printing options, parses ``sys.argv``, and
+    post-processes the result.
+
+    The ``--uniform``/``--unaligned`` shortcuts and the default ``--symlinks``
+    value are applied after parsing, and (when ``import_format_params`` is set)
+    the import-formatting options are collected into an `ImportFormatParams`
+    instance attached as ``options.params``.
+
+    :type addopts:
+      ``callable`` or ``None``
+    :param addopts:
+      Optional callback invoked as ``addopts(parser)`` to register additional,
+      script-specific options on the parser before arguments are parsed.
+    :type import_format_params:
+      ``bool``
+    :param import_format_params:
+      If true, add the "Pretty-printing options" group (e.g. ``--align-imports``,
+      ``--from-spaces``, ``--width``, ``--black``, ``--hanging-indent``,
+      ``--uniform``, ``--unaligned``) and attach the resulting
+      `ImportFormatParams` as ``options.params``.
+    :type modify_action_params:
+      ``bool``
+    :param modify_action_params:
+      If true, add the "Action options" group (e.g. ``--actions``, ``--print``,
+      ``--diff``, ``--replace``, ``--interactive``) and the ``--symlinks``
+      option, which control what is done with files that would be modified.
+    :rtype:
+      ``tuple`` of (``optparse.Values``, ``list`` of ``str``)
+    :return:
+      A ``(options, args)`` pair, where ``options`` holds the parsed option
+      values and ``args`` is the list of remaining positional arguments
+      (typically filenames).
     """
     ### Setup.
     # Register a SIGPIPE handler.

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -125,8 +125,14 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
                 )
 
         def set_actions(actions):
-            actions = tuple(actions)
-            parser.values.actions = actions
+            # Preserve the symlink-handling action, which symlink_callback
+            # keeps at the front of the actions tuple (the default
+            # --symlinks=error is injected before the user's arguments, so it
+            # is parsed first); action options replace only the real actions.
+            current = getattr(parser.values, 'actions', None) or ()
+            symlink_actions = tuple(
+                a for a in current if a in symlink_callbacks.values())
+            parser.values.actions = symlink_actions + tuple(actions)
 
         def action_callback(option, opt_str, value, parser):
             action_args = value.split(',')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -606,6 +606,59 @@ def test_tidy_imports_symlinks_follow():
     assert 'import x' not in output
     assert 'import x' not in symlink_output
 
+def test_tidy_imports_symlinks_replace_action_default_error():
+    """``tidy-imports -r`` on a symlink must error by default (regression:
+    action options used to drop the default --symlinks=error protection, and
+    --replace then replaced the symlink with a regular file)."""
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        try:
+            proc_output = pipe([BIN_DIR+'/tidy-imports', '-r', symlink_name])
+            assert os.path.islink(symlink_name)
+            with open(f.name) as f2:
+                output = f2.read()
+        finally:
+            os.unlink(symlink_name)
+    assert "Error: %s appears to be a symlink" % symlink_name in proc_output
+    assert output == input
+
+
+@pytest.mark.parametrize("args", [
+    ['--symlinks=follow', '-r'],
+    ['-r', '--symlinks=follow'],
+])
+def test_tidy_imports_symlinks_follow_replace_action(args):
+    """``--symlinks=follow`` must be honored together with ``-r`` regardless
+    of option order (regression: a later action option used to wipe the
+    symlink action, and --symlinks=follow before -r was silently ignored)."""
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        try:
+            proc_output = pipe(
+                [BIN_DIR+'/tidy-imports'] + args + [symlink_name])
+            assert os.path.islink(symlink_name)
+            with open(f.name) as f2:
+                output = f2.read()
+        finally:
+            os.unlink(symlink_name)
+    assert "Following symlink %s" % symlink_name in proc_output
+    assert 'import x' not in output
+
+
 def test_tidy_imports_symlinks_skip():
     input = dedent('''
         import x


### PR DESCRIPTION
The default --symlinks=error is injected before the user's arguments, so symlink_callback prepends the symlink-handling action to the actions tuple first.  But every action option (-p/-d/-r/-R/-i/--actions) went through set_actions(), which replaced the whole tuple, silently discarding the symlink action.  As a result `tidy-imports -r link.py` performed no symlink check and atomic_write_file's rename replaced the symlink with a regular file; an explicit `--symlinks=follow` was also ignored when it preceded the action option.

Make set_actions() preserve the symlink-handling actions at the front of the tuple, so action options replace only the real actions and --symlinks composes with them in either order.