### PR TITLE
Fix symlink=error default being ignored; take II

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,4 +140,4 @@ jobs:
           rm /tmp/cpython/Lib/test/tokenizedata/badsyntax_3131.py
           rm /tmp/cpython/Lib/test/tokenizedata/badsyntax_pep3120.py
 
-          uv run python bin/tidy-imports --no-add --no-remove-unused --action=NOTHING /tmp/cpython >/dev/null
+          uv run python bin/tidy-imports --no-add --no-remove-unused --symlink=skip --action=NOTHING /tmp/cpython >/dev/null

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -61,6 +61,42 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
     # casts (runtime changes), which are out of scope for a type-only pass.
     """
     Do setup for a top-level script and parse arguments.
+
+    Performs common setup for pyflyby command-line tools: installs a SIGPIPE
+    handler, builds an `optparse.OptionParser`, registers the standard options
+    (``--debug``, ``--verbose``, ``--quiet``, ``--version``), optionally adds
+    groups of action and/or pretty-printing options, parses ``sys.argv``, and
+    post-processes the result.
+
+    The ``--uniform``/``--unaligned`` shortcuts and the default ``--symlinks``
+    value are applied after parsing, and (when ``import_format_params`` is set)
+    the import-formatting options are collected into an `ImportFormatParams`
+    instance attached as ``options.params``.
+
+    :type addopts:
+      ``callable`` or ``None``
+    :param addopts:
+      Optional callback invoked as ``addopts(parser)`` to register additional,
+      script-specific options on the parser before arguments are parsed.
+    :type import_format_params:
+      ``bool``
+    :param import_format_params:
+      If true, add the "Pretty-printing options" group (e.g. ``--align-imports``,
+      ``--from-spaces``, ``--width``, ``--black``, ``--hanging-indent``,
+      ``--uniform``, ``--unaligned``) and attach the resulting
+      `ImportFormatParams` as ``options.params``.
+    :type modify_action_params:
+      ``bool``
+    :param modify_action_params:
+      If true, add the "Action options" group (e.g. ``--actions``, ``--print``,
+      ``--diff``, ``--replace``, ``--interactive``) and the ``--symlinks``
+      option, which control what is done with files that would be modified.
+    :rtype:
+      ``tuple`` of (``optparse.Values``, ``list`` of ``str``)
+    :return:
+      A ``(options, args)`` pair, where ``options`` holds the parsed option
+      values and ``args`` is the list of remaining positional arguments
+      (typically filenames).
     """
     ### Setup.
     # Register a SIGPIPE handler.
@@ -125,8 +161,14 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
                 )
 
         def set_actions(actions):
-            actions = tuple(actions)
-            parser.values.actions = actions
+            # Preserve the symlink-handling action, which symlink_callback
+            # keeps at the front of the actions tuple (the default
+            # --symlinks=warn is injected before the user's arguments, so it
+            # is parsed first); action options replace only the real actions.
+            current = getattr(parser.values, 'actions', None) or ()
+            symlink_actions = tuple(
+                a for a in current if a in symlink_callbacks.values())
+            parser.values.actions = symlink_actions + tuple(actions)
 
         def action_callback(option, opt_str, value, parser):
             action_args = value.split(',')
@@ -193,7 +235,7 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
             '--symlinks', action='callback', nargs=1, type=str,
             dest='symlinks', callback=symlink_callback, help="--symlinks should be one of: " + symlinks_help,
         )
-        parser.set_defaults(symlinks='error')
+        parser.set_defaults(symlinks="warn")
 
     if import_format_params:
         group = optparse.OptionGroup(parser, "Pretty-printing options")
@@ -273,7 +315,7 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
     # This is the only way to provide a default value for an option with a
     # callback.
     if modify_action_params:
-        args = ["--symlinks=error"] + sys.argv[1:]
+        args = ["--symlinks=warn"] + sys.argv[1:]
     else:
         args = None
 
@@ -569,12 +611,13 @@ def symlink_callback(option, opt_str, value, parser):
     if value in symlink_callbacks:
         parser.values.actions = (symlink_callbacks[value],) + parser.values.actions
     else:
-        raise optparse.OptionValueError("--symlinks must be one of 'error', 'follow', 'skip', or 'replace'. Got %r" % value)
+        raise optparse.OptionValueError("--symlinks must be one of 'error', 'follow', 'skip', 'warn', or 'replace'. Got %r" % value)
 
 symlinks_help = """\
---symlinks=error (default; gives an error on symlinks),
+--symlinks=error (gives an error on symlinks),
 --symlinks=follow (follows symlinks),
 --symlinks=skip (skips symlinks),
+--symlinks=warn (default; skips symlinks with a warning),
 --symlinks=replace (replaces symlinks with the target file\
 """
 
@@ -603,6 +646,13 @@ def symlink_skip(m: Modifier) -> None:
         logger.info("Skipping symlink %s" % m.filename)
         raise AbortActions
 
+def symlink_warn(m: Modifier) -> None:
+    if m.filename == Filename.STDIN:
+        return symlink_follow(m)
+    if m.filename.islink:
+        logger.warn("Skipping symlink %s" % m.filename)
+        raise AbortActions
+
 def symlink_replace(m: Modifier) -> None:
     if m.filename == Filename.STDIN:
         return symlink_follow(m)
@@ -611,10 +661,11 @@ def symlink_replace(m: Modifier) -> None:
         # The current behavior automatically replaces symlinks, so do nothing
 
 symlink_callbacks: Dict[str, _Action] = {
-    'error': symlink_error,
-    'follow': symlink_follow,
-    'skip': symlink_skip,
-    'replace': symlink_replace,
+    "error": symlink_error,
+    "follow": symlink_follow,
+    "skip": symlink_skip,
+    "warn": symlink_warn,
+    "replace": symlink_replace,
 }
 
 def _get_pyproj_toml_file() -> Optional[Path]:

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -525,6 +525,8 @@ def test_tidy_imports_query_junk_1():
 
 
 def test_tidy_imports_symlinks_default():
+    """By default (no --symlinks option), a symlink is skipped with a warning
+    and left untouched."""
     input = dedent('''
         import x
     ''')
@@ -547,7 +549,8 @@ def test_tidy_imports_symlinks_default():
             symlink_output = f2.read()
 
     proc_output = child.logfile.getvalue()
-    assert b"Error: %s appears to be a symlink" % symlink_name.encode("utf-8") in proc_output
+    assert b"Skipping symlink %s" % symlink_name.encode("utf-8") in proc_output
+    assert b"Error" not in proc_output
     assert output == input
     assert symlink_output == input
 
@@ -606,6 +609,59 @@ def test_tidy_imports_symlinks_follow():
     assert 'import x' not in output
     assert 'import x' not in symlink_output
 
+def test_tidy_imports_symlinks_replace_action_default_warn():
+    """``tidy-imports -r`` on a symlink must skip it with a warning by default
+    (regression: action options used to drop the default --symlinks protection,
+    and --replace then replaced the symlink with a regular file)."""
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        try:
+            proc_output = pipe([BIN_DIR+'/tidy-imports', '-r', symlink_name])
+            assert os.path.islink(symlink_name)
+            with open(f.name) as f2:
+                output = f2.read()
+        finally:
+            os.unlink(symlink_name)
+    assert "Skipping symlink %s" % symlink_name in proc_output
+    assert output == input
+
+
+@pytest.mark.parametrize("args", [
+    ['--symlinks=follow', '-r'],
+    ['-r', '--symlinks=follow'],
+])
+def test_tidy_imports_symlinks_follow_replace_action(args):
+    """``--symlinks=follow`` must be honored together with ``-r`` regardless
+    of option order (regression: a later action option used to wipe the
+    symlink action, and --symlinks=follow before -r was silently ignored)."""
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        try:
+            proc_output = pipe(
+                [BIN_DIR+'/tidy-imports'] + args + [symlink_name])
+            assert os.path.islink(symlink_name)
+            with open(f.name) as f2:
+                output = f2.read()
+        finally:
+            os.unlink(symlink_name)
+    assert "Following symlink %s" % symlink_name in proc_output
+    assert 'import x' not in output
+
+
 def test_tidy_imports_symlinks_skip():
     input = dedent('''
         import x
@@ -617,6 +673,37 @@ def test_tidy_imports_symlinks_skip():
         symlink_name = os.path.join(head, 'symlink-' + tail)
         os.symlink(f.name, symlink_name)
         child = pexpect.spawn(python, [BIN_DIR+'/tidy-imports', '--symlinks=skip',
+                                                        symlink_name], timeout=5.0)
+        child.logfile = BytesIO()
+        # child.expect_exact(" [y/N]")
+        # child.send("n\n")
+        child.expect(pexpect.EOF)
+        assert not os.path.islink(f.name)
+        assert os.path.islink(symlink_name)
+        with open(f.name) as f2:
+            output = f2.read()
+        with open(symlink_name) as f2:
+            symlink_output = f2.read()
+
+    proc_output = child.logfile.getvalue()
+    assert b"Skipping symlink %s" % symlink_name.encode("utf-8") in proc_output
+    assert output == input
+    assert symlink_output == input
+
+
+def test_tidy_imports_symlinks_warn():
+    """``--symlinks=warn`` (the default) skips the symlink with a warning and
+    leaves both the symlink and its target untouched."""
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        child = pexpect.spawn(python, [BIN_DIR+'/tidy-imports', '--symlinks=warn',
                                                         symlink_name], timeout=5.0)
         child.logfile = BytesIO()
         # child.expect_exact(" [y/N]")


### PR DESCRIPTION
The default --symlinks=error is injected before the user's arguments, so symlink_callback prepends the symlink-handling action to the actions tuple first.  But every action option (-p/-d/-r/-R/-i/--actions) went through set_actions(), which replaced the whole tuple, silently discarding the symlink action.  As a result `tidy-imports -r link.py` performed no symlink check and atomic_write_file's rename replaced the symlink with a regular file; an explicit `--symlinks=follow` was also ignored when it preceded the action option.

Make set_actions() preserve the symlink-handling actions at the front of the tuple, so action options replace only the real actions and --symlinks composes with them in either order.

This also set the default to warn and add a warn action.

Reverts deshaw/pyflyby#516 (which itself reverts#514) 