### PR TITLE
Fix visit_MatchAs skipping the inner pattern

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -1015,6 +1015,10 @@ class _MissingImportFinder:
 
     def visit_MatchAs(self, node: MatchAs) -> None:
         logger.debug("visit_MatchAs(%r)", node)
+        # Visit the sub-pattern (e.g. the ``Cls()`` in ``case Cls() as x:``)
+        # before binding the capture name.
+        if node.pattern is not None:
+            self.visit(node.pattern)
         if node.name is None:
             return
         return self._visit_Store(node.name)

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -1187,6 +1187,36 @@ def test_find_missing_imports_pattern_match_2():
     assert expected == result
 
 
+def test_find_missing_imports_pattern_match_as_pattern():
+    """Names inside a ``case Cls() as x:`` pattern must be detected
+    (regression: visit_MatchAs never visited the inner pattern)."""
+    code = dedent("""
+    match x:
+        case Point() as p:
+            pass
+    """)
+    result   = find_missing_imports(code, [{'x': 1}])
+    result   = _dilist2strlist(result)
+    expected = ['Point']
+    assert expected == result
+
+
+def test_scan_for_import_issues_pattern_match_as_pattern_not_unused():
+    """An import used only inside a ``case Cls() as x:`` pattern must not be
+    reported unused (regression: visit_MatchAs never visited the inner
+    pattern, so tidy-imports deleted a required import)."""
+    code = dedent("""
+    from foo import Point
+    def f(x):
+        match x:
+            case Point() as p:
+                return p
+    """)
+    missing, unused = scan_for_import_issues(code)
+    assert unused == []
+    assert missing == []
+
+
 def test_find_missing_imports_pattern_match_star_args():
     """Test that *args in match/case patterns are not flagged as undefined names."""
     code = dedent("""


### PR DESCRIPTION
visit_MatchAs stored the capture name and returned without visiting node.pattern, so every name loaded inside an as-pattern (e.g. the class in `case Point() as p:`) was invisible to the scope analysis: imports used only there were reported unused (and deleted by tidy-imports, breaking the code), and missing names there were never auto-imported. Patterns without `as` were unaffected because they fall through to generic_visit.

Visit the sub-pattern before binding the capture name.