### PR TITLE
Remove dead code and fix latent bugs in _dbg.py

### DIFF
--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -3,8 +3,6 @@
 # License: MIT http://opensource.org/licenses/MIT
 
 
-from __future__ import print_function
-
 import builtins
 from   contextlib               import contextmanager
 import errno
@@ -735,9 +733,6 @@ def _send_email_with_attach_instructions(arg, mailto, originalpid):
     if isinstance(arg, FrameType):
         frame       = arg
         stacktrace = ''.join(traceback.format_stack(frame))
-    elif isinstance(arg, TracebackType):
-        frame = d['tb'].tb_frame
-        stacktrace = ''.join(traceback.format_tb(arg))
     elif isinstance(arg, tuple) and len(arg) == 3 and isinstance(arg[2], TracebackType):
         d.update(
             exctype=arg[0].__name__,
@@ -761,7 +756,7 @@ def _send_email_with_attach_instructions(arg, mailto, originalpid):
         filename_abbrev = _abbrev_filename(d['filename']),
     )
     if tb:
-        d['stacktrace'] = tb and ''.join("    %s\n" % (line,) for line in stacktrace.splitlines())
+        d['stacktrace'] = ''.join("    %s\n" % (line,) for line in stacktrace.splitlines())
     # Construct a template for the email body.
     template = []
     template += [
@@ -1296,7 +1291,7 @@ def remote_print_stack(pid, output=1):
         try:
             output_fn = Filename(output.name)
         except Exception:
-            pass
+            output_fn = None
     elif isinstance(output, int):
         output_fh = None
         output_fn = None
@@ -1327,7 +1322,7 @@ def remote_print_stack(pid, output=1):
     if remote_fn is None or not remote_fn.iswritable:
         if not output_fh or output_fd:
             assert remote_fn is not None
-            raise OSError(errno.EACCESS, "Can't write to %s" % output_fn)
+            raise OSError(errno.EACCES, "Can't write to %s" % output_fn)
         # We can still use the /proc/$pid/fd approach with an unnamed temp
         # file.  If it turns out there are situations where that doesn't work,
         # we can switch to using a NamedTemporaryFile.


### PR DESCRIPTION
Dead code removed:
- `from __future__ import print_function`: a no-op on Python 3.
- Redundant `tb and ...` guard in _send_email_with_attach_instructions: the code is already inside an `if tb:` block, so `tb` is always truthy.
- The `elif isinstance(arg, TracebackType):` branch in the same function: it referenced `d['tb']`, a key that is never set on `d`, so the branch could only ever raise KeyError. A bare traceback now falls through to the existing `if not frame: frame = _get_caller_frame()` handling.

Latent bugs fixed:
- remote_print_stack(): when `output` is a file-like object whose `.name` raised, `output_fn` was left unbound, causing a NameError at the later `remote_fn = output_fn`. Now defaulted to None in the except clause.
- remote_print_stack(): `errno.EACCESS` does not exist (AttributeError); corrected to `errno.EACCES`.