### PR TITLE
Remove dead auto_flags machinery from _parse

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -2325,7 +2325,7 @@ def auto_import(
 
 
 def auto_eval(arg: Any, filename: Any = None, mode: Optional[str] = None,
-              flags: Any = None, auto_flags: bool = True,
+              flags: Any = None,
               globals: Optional[Dict[str, Any]] = None,
               locals: Optional[Dict[str, Any]] = None,
               db: Any = None) -> Any:
@@ -2370,10 +2370,6 @@ def auto_eval(arg: Any, filename: Any = None, mode: Optional[str] = None,
       Compilation feature flags, e.g. ["division", "with_statement"].  If
       ``None``, defaults to no flags.  Does not inherit flags from parent
       scope.
-    :type auto_flags:
-      ``bool``
-    :param auto_flags:
-      Whether to try other flags if ``flags`` causes SyntaxError.
     :type globals:
       ``dict``
     :param globals:
@@ -2392,8 +2388,7 @@ def auto_eval(arg: Any, filename: Any = None, mode: Optional[str] = None,
     if isinstance(flags, int):
         assert isinstance(flags, CompilerFlags)
     if isinstance(arg, (str, Filename, FileText, PythonBlock)):
-        block = PythonBlock(arg, filename=filename, flags=flags,
-                            auto_flags=auto_flags)
+        block = PythonBlock(arg, filename=filename, flags=flags)
         flags = block.flags
         filename = block.filename
         arg = block.parse(mode=mode)

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -95,24 +95,8 @@ def _ast_str_literal_value(node: Any) -> Any:
         return None
 
 
-def _flags_to_try(
-    source: str, flags: Any, auto_flags: bool, mode: str
-) -> Iterator[CompilerFlags]:
-    """
-    Flags to try for ``auto_flags``.
-
-    If ``auto_flags`` is False, then only yield ``flags``.
-    If ``auto_flags`` is True, then yield ``flags`` and ``flags ^ print_function``.
-    """
-    flags = CompilerFlags(flags)
-    if re.search(r"# *type:", source):
-        flags = flags | CompilerFlags('type_comments')
-    yield flags
-    return
-
-
 def _parse_ast_nodes(
-    text: FileText, flags: Any, auto_flags: bool, mode: str
+    text: FileText, flags: Any, mode: str
 ) -> AnnotatedModule:
     """
     Parse a block of lines into an AST.
@@ -124,11 +108,6 @@ def _parse_ast_nodes(
       ``FileText``
     :type flags:
       ``CompilerFlags``
-    :type auto_flags:
-      ``bool``
-    :param auto_flags:
-      Whether to guess different flags if ``text`` can't be parsed with
-      ``flags``.
     :param mode:
       Compilation mode: "exec", "single", or "eval".
     :rtype:
@@ -136,31 +115,24 @@ def _parse_ast_nodes(
     """
     assert isinstance(text, FileText)
     filename = str(text.filename) if text.filename else "<unknown>"
-    source = text.joined
-    source = dedent(source)
+    source = dedent(text.joined)
     if not source.endswith("\n"):
         # Ensure that the last line ends with a newline (``ast`` barfs
         # otherwise).
         source += "\n"
-    exp = None
-    for flags in _flags_to_try(source, flags, auto_flags, mode):
-        cflags = ast.PyCF_ONLY_AST | int(flags)
-        try:
-            result = compile(
-                source, filename, mode, flags=cflags, dont_inherit=True)
-        except SyntaxError as e:
-            exp = e
-            pass
-        else:
-            # Attach flags to the result.
-            result.input_flags = flags
-            result.source_flags = CompilerFlags.from_ast(result)
-            result.flags = result.input_flags | result.source_flags
-            result.text = text
-            return result
-    # None, would be unraisable and Mypy would complains below
-    assert exp is not None
-    raise exp
+    flags = CompilerFlags(flags)
+    if re.search(r"# *type:", source):
+        # Honor PEP 484 type comments if any appear to be present.
+        flags = flags | CompilerFlags('type_comments')
+    result = compile(
+        source, filename, mode,
+        flags=ast.PyCF_ONLY_AST | int(flags), dont_inherit=True)
+    # Attach flags to the result.
+    result.input_flags = flags
+    result.source_flags = CompilerFlags.from_ast(result)
+    result.flags = result.input_flags | result.source_flags
+    result.text = text
+    return result
 
 
 
@@ -175,7 +147,7 @@ def _test_parse_string_literal(text: str, flags: Any) -> Any:
     """
     filetext = FileText(text)
     try:
-        module_node = _parse_ast_nodes(filetext, flags, False, "eval")
+        module_node = _parse_ast_nodes(filetext, flags, "eval")
     except SyntaxError:
         return None
     body = module_node.body
@@ -550,7 +522,6 @@ class PythonBlock:
     """
 
     text: FileText
-    _auto_flags: bool
     _input_flags: Union[int,CompilerFlags]
 
     def __new__(
@@ -559,7 +530,6 @@ class PythonBlock:
         filename: Any = None,
         startpos: Any = None,
         flags: Any = None,
-        auto_flags: Optional[bool] = None,
     ) -> "PythonBlock":
         if isinstance(arg, PythonStatement):
             arg = arg.block
@@ -572,8 +542,7 @@ class PythonBlock:
             # Fall through
         if isinstance(arg, (FileText, Filename, str)):
             return cls.from_text(
-                arg, filename=filename, startpos=startpos,
-                flags=flags, auto_flags=auto_flags)
+                arg, filename=filename, startpos=startpos, flags=flags)
         raise TypeError("%r: unexpected %r"
                         % (cls.__name__, type(arg).__name__,))
 
@@ -588,7 +557,6 @@ class PythonBlock:
         filename: Any = None,
         startpos: Any = None,
         flags: Any = None,
-        auto_flags: Any = False,
     ) -> "PythonBlock":
         """
         :type text:
@@ -605,8 +573,6 @@ class PythonBlock:
           ``CompilerFlags``
         :param flags:
           Input compiler flags.
-        :param auto_flags:
-          Whether to try other flags if ``flags`` fails.
         :rtype:
           `PythonBlock`
         """
@@ -616,7 +582,6 @@ class PythonBlock:
         self = object.__new__(cls)
         self.text = FileText(text, filename=filename, startpos=startpos)
         self._input_flags = CompilerFlags(flags)
-        self._auto_flags = auto_flags
         return self
 
     @classmethod
@@ -637,7 +602,6 @@ class PythonBlock:
         self.text                         = text
         self.flags                        = flags
         self._input_flags                 = flags
-        self._auto_flags                  = False
         return self
 
     @classmethod
@@ -703,7 +667,7 @@ class PythonBlock:
         # in which case this code does not run.
         try:
             return _parse_ast_nodes(
-                self.text, self._input_flags, self._auto_flags, "exec")
+                self.text, self._input_flags, "exec")
         except Exception as e:
             # Add the filename to the exception message to be nicer.
             if self.text.filename:

--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -374,9 +374,7 @@ $ py --debug    PID                        Attach debugger to PID
 $ py                                       IPython shell
 """.strip()
 
-# Default compiler flags (feature flags) used for all user code.  We include
-# "print_function" here, but we also use auto_flags=True, which means
-# print_function may be flipped off if the code contains print statements.
+# Default compiler flags (feature flags) used for all user code.
 FLAGS = CompilerFlags(["absolute_import", "with_statement", "division",
                        "print_function"])
 
@@ -1404,7 +1402,7 @@ class _Namespace(object):
         #   auto_eval(arg, mode=mode, flags=FLAGS, globals=self.globals)
         # but better logging and error raising.
         if not isinstance(block, PythonBlock):
-            block = PythonBlock(block, flags=FLAGS, auto_flags=True)
+            block = PythonBlock(block, flags=FLAGS)
         if auto_import and not self.auto_import(block):
             missing = find_missing_imports(block, [self.globals])
             mstr = ", ".join(repr(str(x)) for x in missing)
@@ -2016,8 +2014,7 @@ class _PyMain(object):
             if (args and
                 self.arg_mode == None and
                 not any(re.match(r"\s*$|-[a-zA-Z-]", a) for a in args)):
-                cmd = PythonBlock(" ".join([arg0]+args),
-                                  flags=FLAGS, auto_flags=True)
+                cmd = PythonBlock(" ".join([arg0]+args), flags=FLAGS)
                 if cmd.parsable and self.namespace.auto_import(cmd):
                     with SysArgvCtx("-c"):
                         output_mode = _interpret_output_mode(self.output_mode)
@@ -2028,7 +2025,7 @@ class _PyMain(object):
                         return
                 # else fall through
             # Heuristic based on first arg: try run_module, apply, or exec/eval.
-            cmd = PythonBlock(arg0, flags=FLAGS, auto_flags=True)
+            cmd = PythonBlock(arg0, flags=FLAGS)
             if not cmd.parsable:
                 logger.error(
                     "Could not interpret as filename or expression: %s",

--- a/lib/python/pyflyby/check_parse.py
+++ b/lib/python/pyflyby/check_parse.py
@@ -75,7 +75,7 @@ def parse_file(file_path: Path) -> Tuple[bool, str]:
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("error", SyntaxWarning)
-            block = PythonBlock(content, auto_flags=True)
+            block = PythonBlock(content)
 
             # Access the annotated_ast_node to ensure it's created without errors
             _ = block.annotated_ast_node

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -2093,36 +2093,36 @@ def test_auto_eval_exec_1():
 
 
 def test_auto_eval_no_auto_flags_ps_flagps_1(capsys):
-    auto_eval("print(3.00)", flags=CompilerFlags.from_int(0), auto_flags=False)
+    auto_eval("print(3.00)", flags=CompilerFlags.from_int(0))
     out, _ = capsys.readouterr()
     assert out == "3.0\n"
 
 def test_auto_eval_no_auto_flags_ps_flag_pf1():
     with pytest.raises(SyntaxError):
-        auto_eval("print 3.00", flags="print_function", auto_flags=False)
+        auto_eval("print 3.00", flags="print_function")
 
 
 def test_auto_eval_no_auto_flags_pf_flag_pf1(capsys):
     auto_eval("print(3.00, file=sys.stdout)",
-              flags="print_function", auto_flags=False)
+              flags="print_function")
     out, _ = capsys.readouterr()
     assert out == "[PYFLYBY] import sys\n3.0\n"
 
 
 def test_auto_eval_auto_flags_ps_flagps_1(capsys):
     with pytest.raises(SyntaxError):
-        auto_eval("print 3.00", flags=CompilerFlags.from_int(0), auto_flags=True)
+        auto_eval("print 3.00", flags=CompilerFlags.from_int(0))
 
 
 def test_auto_eval_auto_flags_pf_flagps_1(capsys):
-    auto_eval("print(3.00, file=sys.stdout)", flags=CompilerFlags.from_int(0), auto_flags=True)
+    auto_eval("print(3.00, file=sys.stdout)", flags=CompilerFlags.from_int(0))
     out, _ = capsys.readouterr()
     assert out == "[PYFLYBY] import sys\n3.0\n"
 
 
 def test_auto_eval_auto_flags_pf_flag_pf1(capsys):
     auto_eval("print(3.00, file=sys.stdout)",
-              flags=CompilerFlags("print_function"), auto_flags=True)
+              flags=CompilerFlags("print_function"))
     out, _ = capsys.readouterr()
     assert out == "[PYFLYBY] import sys\n3.0\n"
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1239,7 +1239,7 @@ def test_PythonBlock_no_auto_flags_pn_futpf_1():
 def test_PythonBlock_auto_flags_pf_flagps_1():
     block = PythonBlock(dedent('''
         print(42, out=x)
-    ''').lstrip(), auto_flags=True)
+    ''').lstrip())
     assert not (block.flags                & "print_function")
     assert not (block.ast_node.input_flags & "print_function")
     assert not (block.source_flags         & "print_function")
@@ -1248,7 +1248,7 @@ def test_PythonBlock_auto_flags_pf_flagps_1():
 def test_PythonBlock_auto_flags_pf_flagpf_1():
     block = PythonBlock(dedent('''
         print(42, out=x)
-    ''').lstrip(), flags="print_function", auto_flags=True)
+    ''').lstrip(), flags="print_function")
     assert     (block.flags                & "print_function")
     assert     (block.ast_node.input_flags & "print_function")
     assert not (block.source_flags         & "print_function")
@@ -1258,7 +1258,7 @@ def test_PythonBlock_auto_flags_pf_flagps_futpf_1():
     block = PythonBlock(dedent('''
         from __future__ import print_function
         print(42, out=x)
-    ''').lstrip(), auto_flags=True)
+    ''').lstrip())
     assert     (block.flags                & "print_function")
     assert not (block.ast_node.input_flags & "print_function")
     assert     (block.source_flags         & "print_function")
@@ -1268,7 +1268,7 @@ def test_PythonBlock_auto_flags_pf_flagpf_futpf_1():
     block = PythonBlock(dedent('''
         from __future__ import print_function
         print(42, out=x)
-    ''').lstrip(), flags="print_function", auto_flags=True)
+    ''').lstrip(), flags="print_function")
     assert     (block.flags                & "print_function")
     assert     (block.ast_node.input_flags & "print_function")
     assert     (block.source_flags         & "print_function")
@@ -1277,7 +1277,7 @@ def test_PythonBlock_auto_flags_pf_flagpf_futpf_1():
 def test_PythonBlock_auto_flags_px_flagps_1():
     block = PythonBlock(dedent('''
         print(42)
-    ''').lstrip(), auto_flags=True)
+    ''').lstrip())
     assert not (block.flags                & "print_function")
     assert not (block.ast_node.input_flags & "print_function")
     assert not (block.source_flags         & "print_function")
@@ -1286,7 +1286,7 @@ def test_PythonBlock_auto_flags_px_flagps_1():
 def test_PythonBlock_auto_flags_px_flagpf_1():
     block = PythonBlock(dedent('''
         print(42)
-    ''').lstrip(), flags="print_function", auto_flags=True)
+    ''').lstrip(), flags="print_function")
     assert     (block.flags                & "print_function")
     assert     (block.ast_node.input_flags & "print_function")
     assert not (block.source_flags         & "print_function")
@@ -1296,7 +1296,7 @@ def test_PythonBlock_auto_flags_px_flagps_futpf_1():
     block = PythonBlock(dedent('''
         from __future__ import print_function
         print(42)
-    ''').lstrip(), auto_flags=True)
+    ''').lstrip())
     assert     (block.flags                & "print_function")
     assert not (block.ast_node.input_flags & "print_function")
     assert     (block.source_flags         & "print_function")
@@ -1306,7 +1306,7 @@ def test_PythonBlock_auto_flags_px_flagpf_futpf_1():
     block = PythonBlock(dedent('''
         from __future__ import print_function
         print(42)
-    ''').lstrip(), flags="print_function", auto_flags=True)
+    ''').lstrip(), flags="print_function")
     assert     (block.flags                & "print_function")
     assert     (block.ast_node.input_flags & "print_function")
     assert     (block.source_flags         & "print_function")
@@ -1315,7 +1315,7 @@ def test_PythonBlock_auto_flags_px_flagpf_futpf_1():
 def test_PythonBlock_auto_flags_pn_flagps_1():
     block = PythonBlock(dedent('''
         42
-    ''').lstrip(), auto_flags=True)
+    ''').lstrip())
     assert not (block.flags                & "print_function")
     assert not (block.ast_node.input_flags & "print_function")
     assert not (block.source_flags         & "print_function")
@@ -1324,7 +1324,7 @@ def test_PythonBlock_auto_flags_pn_flagps_1():
 def test_PythonBlock_auto_flags_pn_flagpf_1():
     block = PythonBlock(dedent('''
         42
-    ''').lstrip(), flags="print_function", auto_flags=True)
+    ''').lstrip(), flags="print_function")
     assert     (block.flags                & "print_function")
     assert     (block.ast_node.input_flags & "print_function")
     assert not (block.source_flags         & "print_function")
@@ -1334,7 +1334,7 @@ def test_PythonBlock_auto_flags_pn_flagps_futpf_1():
     block = PythonBlock(dedent('''
         from __future__ import print_function
         42
-    ''').lstrip(), auto_flags=True)
+    ''').lstrip())
     assert     (block.flags                & "print_function")
     assert not (block.ast_node.input_flags & "print_function")
     assert     (block.source_flags         & "print_function")
@@ -1344,7 +1344,7 @@ def test_PythonBlock_auto_flags_pn_flagpf_futpf_1():
     block = PythonBlock(dedent('''
         from __future__ import print_function
         42
-    ''').lstrip(), flags="print_function", auto_flags=True)
+    ''').lstrip(), flags="print_function")
     assert     (block.flags                & "print_function")
     assert     (block.ast_node.input_flags & "print_function")
     assert     (block.source_flags         & "print_function")
@@ -1365,7 +1365,7 @@ def test_PythonStatement_flags_1():
 def test_PythonStatement_auto_flags_1():
     block = PythonBlock(
         "from __future__ import unicode_literals\nprint(1,file=x)\n",
-        flags="division", auto_flags=True)
+        flags="division")
     s0, s1 = block.statements
     assert s0.block.source_flags == CompilerFlags("unicode_literals")
     with warnings.catch_warnings():
@@ -1392,7 +1392,7 @@ def test_parsable_explicit_flags_1():
 
 
 def test_parsable_missing_flags_auto_flags_1():
-    block = PythonBlock("print(3, file=4)", auto_flags=True)
+    block = PythonBlock("print(3, file=4)")
     assert block.parsable
 
 
@@ -1406,7 +1406,7 @@ def test_parsable_missing_flags_auto_flags_1():
     ],
 )
 def test_parsable_Call_Ast_args_kwargs(input):
-    block = PythonBlock(input, auto_flags=True)
+    block = PythonBlock(input)
     assert block.annotated_ast_node
 
 
@@ -1420,7 +1420,7 @@ def func(x: List[int], y: List[int]) -> List[int]:
     ],
 )
 def test_parsable_annotation_order(input):
-    block = PythonBlock(input, auto_flags=True)
+    block = PythonBlock(input)
     assert block.annotated_ast_node
 
 
@@ -1456,7 +1456,7 @@ is the value.
     ],
 )
 def test_parse_f_string_ast_ann(input):
-    block = PythonBlock(input, auto_flags=True)
+    block = PythonBlock(input)
     assert block.annotated_ast_node
 
 
@@ -1490,7 +1490,7 @@ func(arg=f"""
     ],
 )
 def test_join_formatted_string_columns(input):
-    block = PythonBlock(input, auto_flags=True)
+    block = PythonBlock(input)
     assert block.annotated_ast_node
 
 
@@ -1520,7 +1520,7 @@ info = f'{name=}, {age=}'
 )
 def test_fstring_debug_expressions(input):
     """Test that f-string debug expressions (f'{x=}') are handled correctly."""
-    block = PythonBlock(input, auto_flags=True)
+    block = PythonBlock(input)
     assert block.annotated_ast_node
 
 
@@ -1546,7 +1546,7 @@ info = t"{name=}, {age=}"
 )
 def test_template_string_debug_expressions(input):
     """Test that template string debug expressions (t'{x=}') are handled correctly."""
-    block = PythonBlock(input, auto_flags=True)
+    block = PythonBlock(input)
     assert block.annotated_ast_node
 
 
@@ -1577,7 +1577,7 @@ def test_template_string_debug_expressions(input):
 )
 def test_type_parameters(input):
     """Test that PEP 695 type parameters (def func[T](...)) are handled correctly."""
-    block = PythonBlock(dedent(input), auto_flags=True)
+    block = PythonBlock(dedent(input))
     assert block.annotated_ast_node
 
 
@@ -1599,7 +1599,7 @@ print(b"""
     ],
 )
 def test_bytes_concat(input):
-    block = PythonBlock(input, auto_flags=True)
+    block = PythonBlock(input)
     assert block.annotated_ast_node
 
 
@@ -1680,7 +1680,7 @@ def test_decorator_with_whitespace(code):
     This is valid Python syntax (though discouraged by style guides like PEP 8).
     These tests verify that pyflyby can handle decorators with whitespace after @.
     """
-    block = PythonBlock(dedent(code).strip(), auto_flags=True)
+    block = PythonBlock(dedent(code).strip())
     assert block.annotated_ast_node
 
 


### PR DESCRIPTION
auto_flags has been inert since Python 2 support was dropped: _flags_to_try always yielded a single flag set (the print_function flipping its docstring described was already gone), so the retry loop in _parse_ast_nodes could never retry and auto_flags=True/False produced identical results.

- Delete _flags_to_try and collapse _parse_ast_nodes to a single compile() (it still honors `# type:` comments).
- Drop the auto_flags parameter from PythonBlock.__new__/from_text and the _auto_flags attribute, from auto_eval, and from all callers (_py.py, check_parse.py).
- Drop the now-inert auto_flags= kwarg from the tests that passed it; their flag-propagation assertions are unchanged.