### PR TITLE
Fix tidy-import does not respect --width

### DIFF
--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -737,7 +737,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
                 block_idx, block._output.startpos.lineno
             )
             for lineno in sorted(by_lineno, reverse=True):
-                self._rewrite_local_import_statement(
+                lines = self._rewrite_local_import_statement(
                     lines, lineno - original_startpos, by_lineno[lineno],
                     lineno, params)
             block._output = PythonBlock(
@@ -747,7 +747,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
     def _rewrite_local_import_statement(
         self, lines: List[str], rel: int, imps: List[Import], lineno: int,
         params: ImportFormatParams
-    ) -> None:
+    ) -> List[str]:
         """
         Rewrite the import statement starting at ``lines[rel]`` with the
         imports in ``imps`` removed.  Co-located code -- other aliases in the
@@ -756,7 +756,8 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         are deleted only when nothing else remains on them.
 
         :param lines:
-          Source lines of the block, modified in place.
+          Source lines of the block.  This list is not modified; the rewritten
+          lines are returned instead.
         :param rel:
           Index into ``lines`` of the first line of the import statement.
         :param imps:
@@ -767,12 +768,18 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
           Formatting parameters.  When the import occupies its own line(s),
           the surviving statement is re-wrapped according to these parameters
           (e.g. ``--width``).
+        :return:
+          A new list of lines with the rewrite applied.  When nothing can be
+          rewritten (e.g. the statement can't be parsed), a copy of the
+          original ``lines`` is returned unchanged.
         """
+        # Work on a copy so the caller's list is never mutated in place.
+        lines = list(lines)
         if not (0 <= rel < len(lines)):
             logger.warning(
                 "Line %d out of range (relative %d, %d lines in block)",
                 lineno, rel, len(lines))
-            return
+            return lines
         first_line = lines[rel]
         indent_str = first_line[: len(first_line) - len(first_line.lstrip())]
         # Find the physical extent of the statement: extend line by line until
@@ -791,7 +798,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
             logger.warning(
                 "Couldn't parse statement at line %d; leaving it untouched",
                 lineno)
-            return
+            return lines
         src_lines = candidate.split("\n")
         # Find the import node containing the imports to remove.  (The line
         # may hold several semicolon-separated statements.)
@@ -811,7 +818,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
             logger.warning(
                 "Couldn't find import(s) %s at line %d; leaving line untouched",
                 ", ".join(map(str, imps)), lineno)
-            return
+            return lines
         remaining = [imp for imp in target_stmt.imports if imp not in matched]
         # Splice the rewritten statement between the text surrounding it.
         # WARNING: col_offset/end_col_offset are in bytes, not characters.
@@ -833,7 +840,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
                 indent_str + line if line else line
                 for line in rendered.split("\n")
             ]
-            return
+            return lines
         if remaining:
             new_text = (
                 prefix + str(ImportStatement._from_imports(remaining)) + suffix)
@@ -854,6 +861,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         else:
             del lines[rel: end + 1]
             _maybe_insert_pass(lines, rel, len(indent_str), lineno)
+        return lines
 
     def select_import_block_by_closest_prefix_match(
         self, imp: Import, max_lineno: Union[int, float]

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -820,7 +820,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
                 ", ".join(map(str, imps)), lineno)
             return lines
         remaining = [imp for imp in target_stmt.imports if imp not in matched]
-        # Splice the rewritten statement between the text surrounding it.
+        # Build the replacement line(s) for the statement, then splice them in.
         # WARNING: col_offset/end_col_offset are in bytes, not characters.
         assert target.lineno is not None
         assert target.end_lineno is not None
@@ -828,23 +828,11 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
                   .encode()[: target.col_offset].decode())
         suffix = (src_lines[target.end_lineno - 1]
                   .encode()[target.end_col_offset:].decode())
-        if remaining and not prefix.strip() and not suffix.strip():
-            width = params.max_line_length
-            if width is None:
-                width = params.max_line_length_default
-            sub_params = ImportFormatParams(
-                params, max_line_length=max(width - len(indent_str), 1))
-            rendered = ImportStatement._from_imports(remaining).pretty_print(
-                sub_params).rstrip("\n")
-            lines[rel: end + 1] = [
-                indent_str + line if line else line
-                for line in rendered.split("\n")
-            ]
-            return lines
-        if remaining:
-            new_text = (
-                prefix + str(ImportStatement._from_imports(remaining)) + suffix)
-        else:
+        if not remaining:
+            # The whole statement is removed; reassemble any co-located code
+            # (semicolon-separated statements) that shared its line(s).  An
+            # empty ``ImportStatement`` is not constructible, so this case
+            # cannot share the rendering path below.
             before = prefix.rstrip()
             after = suffix.lstrip()
             # Drop the semicolon that used to join the import to its neighbor.
@@ -852,14 +840,32 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
                 before = before[:-1].rstrip()
             elif after.startswith(";"):
                 after = after[1:].lstrip()
-            if before and after:
-                new_text = before + "; " + after
-            else:
-                new_text = before or after
-        if new_text.strip():
-            lines[rel: end + 1] = [indent_str + new_text]
+            new_text = (before + "; " + after) if before and after \
+                else (before or after)
+            new_lines = [indent_str + new_text] if new_text.strip() else []
+        elif prefix.strip() or suffix.strip():
+            # Co-located code on the same line; keep everything on one line so
+            # we don't have to interleave it with a wrapped import.
+            stmt_text = str(ImportStatement._from_imports(remaining))
+            new_lines = [indent_str + prefix + stmt_text + suffix]
         else:
-            del lines[rel: end + 1]
+            # The import occupies its own line(s); pretty-print it so that the
+            # configured width applies to local imports just as it does to
+            # top-level ones.  The rendered text starts at column 0, so reduce
+            # the available width by the indentation and re-indent each line.
+            width = params.max_line_length
+            if width is None:
+                width = params.max_line_length_default
+            sub_params = ImportFormatParams(
+                params, max_line_length=max(width - len(indent_str), 1))
+            rendered = ImportStatement._from_imports(remaining).pretty_print(
+                sub_params).rstrip("\n")
+            new_lines = [
+                indent_str + line if line else line
+                for line in rendered.split("\n")
+            ]
+        lines[rel: end + 1] = new_lines
+        if not new_lines:
             _maybe_insert_pass(lines, rel, len(indent_str), lineno)
         return lines
 

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -441,7 +441,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
     def pretty_print(self, params: Any = None) -> FileText:
         params = ImportFormatParams(params)
         # Apply deferred local-import removals before rendering the blocks.
-        self._apply_local_import_removals()
+        self._apply_local_import_removals(params)
         result = [block.pretty_print(params=params) for block in self.blocks]
         output = FileText.concatenate(result)
 
@@ -692,7 +692,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
 
         return imp
 
-    def _apply_local_import_removals(self) -> None:
+    def _apply_local_import_removals(self, params: ImportFormatParams) -> None:
         """
         Apply the local-import removals recorded by ``remove_import``.
 
@@ -700,6 +700,11 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         aliases removed from one statement are handled in a single rewrite,
         and statements are processed bottom-up within each block so that
         edits never shift the line numbers of statements not yet processed.
+
+        :param params:
+          Formatting parameters used to re-wrap the surviving local imports,
+          so that options like ``--width`` apply to local imports just as they
+          do to top-level ones.
         """
         if not self._pending_local_removals:
             return
@@ -733,13 +738,15 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
             )
             for lineno in sorted(by_lineno, reverse=True):
                 self._rewrite_local_import_statement(
-                    lines, lineno - original_startpos, by_lineno[lineno], lineno)
+                    lines, lineno - original_startpos, by_lineno[lineno],
+                    lineno, params)
             block._output = PythonBlock(
                 "\n".join(lines), filename=block._output.filename
             )
 
     def _rewrite_local_import_statement(
-        self, lines: List[str], rel: int, imps: List[Import], lineno: int
+        self, lines: List[str], rel: int, imps: List[Import], lineno: int,
+        params: ImportFormatParams
     ) -> None:
         """
         Rewrite the import statement starting at ``lines[rel]`` with the
@@ -756,6 +763,10 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
           The `Import` s to remove from the statement.
         :param lineno:
           Absolute line number in the file (for logging).
+        :param params:
+          Formatting parameters.  When the import occupies its own line(s),
+          the surviving statement is re-wrapped according to these parameters
+          (e.g. ``--width``).
         """
         if not (0 <= rel < len(lines)):
             logger.warning(
@@ -810,6 +821,19 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
                   .encode()[: target.col_offset].decode())
         suffix = (src_lines[target.end_lineno - 1]
                   .encode()[target.end_col_offset:].decode())
+        if remaining and not prefix.strip() and not suffix.strip():
+            width = params.max_line_length
+            if width is None:
+                width = params.max_line_length_default
+            sub_params = ImportFormatParams(
+                params, max_line_length=max(width - len(indent_str), 1))
+            rendered = ImportStatement._from_imports(remaining).pretty_print(
+                sub_params).rstrip("\n")
+            lines[rel: end + 1] = [
+                indent_str + line if line else line
+                for line in rendered.split("\n")
+            ]
+            return
         if remaining:
             new_text = (
                 prefix + str(ImportStatement._from_imports(remaining)) + suffix)

--- a/tests/test_imports2s_bis.py
+++ b/tests/test_imports2s_bis.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import pytest
 from   textwrap                 import dedent
 
+from   pyflyby._format          import FormatParams
 from   pyflyby._importdb        import ImportDB
 from   pyflyby._imports2s       import fix_unused_and_missing_imports
 from   pyflyby._parse           import PythonBlock
@@ -401,6 +402,33 @@ def test_tidy_local_imports_flag(
     for s in expect_absent:
         with subtests.test(msg="absent", i=s):
             assert s not in result, f"expected {s!r} to be absent"
+
+
+@pytest.mark.parametrize("width", (79, 60, 40))
+def test_tidy_local_imports_respect_width(width):
+    """Local imports tidied with ``tidy_local_imports`` should be wrapped
+    according to the configured ``--width`` (max_line_length), just like
+    top-level imports."""
+    code = (
+        "def foo():\n"
+        "    from aaa.bbb.ccc.ddd import (eee, fff, ggg, hhh, iii, jjj, kkk,\n"
+        "        lll, mmm, nnn, ooo, ppp, qqq, rrr)\n"
+        "    print(eee, fff, ggg, hhh)\n"
+        "    print(iii, jjj, kkk, lll)\n"
+        "    print(nnn, ooo, ppp, qqq, rrr)\n"
+    )
+    input_block = PythonBlock(code)
+    db = ImportDB("")
+    output = fix_unused_and_missing_imports(
+        input_block, db=db, tidy_local_imports=True,
+        params=FormatParams(max_line_length=width),
+    )
+    result = str(output)
+    # The unused ``mmm`` is removed...
+    assert "mmm" not in result
+    # ...and every line honours the configured width.
+    for line in result.split("\n"):
+        assert len(line) <= width, f"line exceeds width {width}: {line!r}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Should close Quansight/deshaw#697

This was as intuited the fact that we were not looking at the depth of indentation; so we need to consider it as well as pass the required option;

We further improve the code a bit by refactoring the order of conditional; and make sure we do not mutate arguments. This is a slight change of internal API; but makes reasoning about it a bit simpler.