### PR TITLE
Improve `__forget_imports__` support, fix crash on sub-import

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -2171,6 +2171,7 @@ def auto_import_symbol(
     if DottedIdentifier(fullname) in autoimported:
         logger.debug("auto_import_symbol(%r): already attempted", fullname)
         return False
+    db = ImportDB.interpret_arg(db, target_filename=".")
     # See whether there's a known import for this name.  This is mainly
     # important for things like "from numpy import arange".  Imports such as
     # "import sqlalchemy.orm" will also be handled by this, although it's less
@@ -2226,10 +2227,21 @@ def auto_import_symbol(
     # "foo.bar.baz", and the known imports database only knew about "import
     # foo.bar").  For each component that may need importing, check if the
     # loader thinks it should be importable, and if so import it.
+    forgotten = set(db.forget_imports.imports)
     for pmodule in ModuleHandle(fullname).ancestors:
         if not symbol_needs_import(pmodule.name, namespaces):
             continue
         pmodule_name = DottedIdentifier(pmodule.name)
+        # Respect `__forget_imports__`: if the user asked us to forget e.g.
+        # "import numpy", don't silently import it here just because it happens
+        # to be an importable module.  Note: "from foo import bar" forget produces
+        # a different Import than "import foo", so forgetting a symbol does not
+        # suppress importing its parent module.
+        if Import.from_parts(str(pmodule_name), str(pmodule_name)) in forgotten:
+            logger.debug("auto_import_symbol(%r): %r is in __forget_imports__; "
+                         "not importing", fullname, pmodule_name)
+            autoimported[pmodule_name] = False
+            return False
         if pmodule_name in autoimported:
             if not autoimported[pmodule_name]:
                 logger.debug("auto_import_symbol(%r): stopping because "

--- a/lib/python/pyflyby/_importdb.py
+++ b/lib/python/pyflyby/_importdb.py
@@ -493,8 +493,11 @@ class ImportDB:
         :rtype:
           ``dict`` mapping from ``str`` to tuple of `Import` s
         """
-        # TODO: make known_imports take into account the below forget_imports,
-        # then move this function into ImportSet
+        # Note: ``self.known_imports`` already has ``forget_imports`` removed
+        # (see `_from_data`).  We still subtract ``forget_imports`` again below
+        # because the prefix entries synthesized here (e.g. the "import foo.bar"
+        # implied by "from foo.bar import quux") are not present verbatim in
+        # ``known_imports`` and therefore aren't covered by that removal.
         d = defaultdict(set)
         for imp in self.known_imports.imports:
             # Given an import like "from foo.bar import quux as QUUX", add the
@@ -508,8 +511,14 @@ class ImportDB:
             d[imp.import_as].add(imp)
             for prefix in dotted_prefixes(imp.fullname)[:-1]:
                 d[prefix].add(Import.from_parts(prefix, prefix))
-        return dict( (k, tuple(sorted(v - set(self.forget_imports.imports))))
-                     for k, v in d.items())
+        forget = set(self.forget_imports.imports)
+        # Drop entries that become empty after removing forgotten imports; an
+        # empty tuple here would otherwise trip up callers such as
+        # `get_known_import`, which assume every key maps to >= 1 import.
+        return dict( (k, tuple(sorted(remaining)))
+                     for k, v in d.items()
+                     for remaining in [v - forget]
+                     if remaining )
 
     def __repr__(self) -> str:
         printed = self.pretty_print()

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -2256,6 +2256,115 @@ def test_auto_import_unknown_but_in_db1(tpp, capsys):
     assert out.startswith(expected)
 
 
+def test_auto_import_forget_1(capsys):
+    # Verify that a forgotten import is not auto-imported, even though it would
+    # otherwise be a known import.
+    db = ImportDB('''
+        from base64 import b64decode, b64encode
+        __forget_imports__ = ['from base64 import b64decode']
+    ''')
+    ns = {}
+    auto_import("b64decode", [ns], db=db)
+    out, _ = capsys.readouterr()
+    assert out == ""
+    assert "b64decode" not in ns
+    # A sibling import that was not forgotten still works.
+    auto_import("b64encode", [ns], db=db)
+    out, _ = capsys.readouterr()
+    assert out == "[PYFLYBY] from base64 import b64encode\n"
+    assert "b64encode" in ns
+
+
+def test_auto_import_forget_prefix_no_crash_1(capsys):
+    # Regression test: forgetting a prefix module import while a member import
+    # remains must not produce an empty by_fullname_or_import_as entry, which
+    # previously tripped an assertion in auto_import_symbol.
+    from pyflyby._autoimp import get_known_import
+    db = ImportDB('''
+        from base64 import b64encode
+        __forget_imports__ = ['import base64']
+    ''')
+    # 'base64' must not map to an empty tuple (nor be present at all).
+    assert 'base64' not in db.by_fullname_or_import_as
+    assert get_known_import('base64', db=db) is None
+    # Auto-importing a member completes cleanly (no AssertionError), and since
+    # 'import base64' was forgotten, base64 is not imported.
+    ns = {}
+    result = auto_import("base64.b64encode", [ns], db=db)
+    out, _ = capsys.readouterr()
+    assert result is False
+    assert out == ""
+    assert 'base64' not in ns
+
+
+def test_auto_import_forget_module_with_from_imports_no_crash_1(capsys):
+    # Regression for the reported crash scenario: a ~/.pyflyby containing
+    #     __forget_imports__ = ["import collections"]
+    # combined with the default db's "from collections import defaultdict" etc.
+    from pyflyby._autoimp import get_known_import
+    db = ImportDB('from collections import defaultdict, OrderedDict\n'
+                  '__forget_imports__ = ["import collections"]')
+    assert 'collections' not in db.by_fullname_or_import_as
+    assert get_known_import('collections', db=db) is None
+    ns = {}
+    result = auto_import("collections", [ns], db=db)   # bare module reference
+    out, _ = capsys.readouterr()
+    assert result is False
+    assert out == ""
+    assert "collections" not in ns
+    # The sibling "from collections import defaultdict" is unaffected.
+    assert get_known_import('defaultdict', db=db) == (
+        Import('from collections import defaultdict'),)
+
+
+def test_auto_import_forget_module_name_1(capsys):
+    # Forgetting a plain module import ("import X") suppresses auto-import of
+    # that module even though it is a genuinely importable module (i.e. the
+    # module-loader fallback must also respect __forget_imports__).
+    db = ImportDB('__forget_imports__ = ["import os"]')
+    ns = {}
+    result = auto_import("os.getpid()", [ns], db=db)
+    out, _ = capsys.readouterr()
+    assert result is False
+    assert out == ""
+    assert "os" not in ns
+
+
+def test_auto_import_forget_aliased_import_1(capsys):
+    # Forgetting an aliased import ("import numpy as np") suppresses the alias.
+    db = ImportDB('import numpy as np\n'
+                  '__forget_imports__ = ["import numpy as np"]')
+    ns = {}
+    result = auto_import("np.arange", [ns], db=db)
+    _out, _ = capsys.readouterr()
+    assert result is False
+    assert "np" not in ns
+
+
+def test_auto_import_forget_from_db_config_1(capsys):
+    # A __forget_imports__ declared in the database (i.e. via a .pyflyby config
+    # file) is honored by the module-loader fallback too, so a plain "import X"
+    # forget suppresses the module even when X is genuinely importable.
+    db = ImportDB('import fractions\n__forget_imports__ = ["import fractions"]')
+    ns = {}
+    result = auto_import("fractions.Fraction", [ns], db=db)
+    _out, _ = capsys.readouterr()
+    assert result is False
+    assert "fractions" not in ns
+
+
+def test_auto_import_forget_symbol_keeps_parent_module_1(capsys):
+    # Forgetting "from os import getpid" must NOT suppress importing the module
+    # os itself (e.g. when accessed as os.path); only the symbol is forgotten.
+    db = ImportDB('__forget_imports__ = ["from os import getpid"]')
+    ns = {}
+    result = auto_import("os.path", [ns], db=db)
+    out, _ = capsys.readouterr()
+    assert result is True
+    assert out == "[PYFLYBY] import os\n"
+    assert "os" in ns
+
+
 def test_auto_import_fake_importerror_1(tpp, capsys):
     writetext(tpp/"proton24412521.py", """
         raise ImportError("No module named proton24412521")

--- a/tests/test_importdb.py
+++ b/tests/test_importdb.py
@@ -83,6 +83,41 @@ def test_ImportDB_by_fullname_or_import_as_1():
     assert result == expected
 
 
+def test_ImportDB_by_fullname_or_import_as_forget_1():
+    # A forgotten import should not appear in by_fullname_or_import_as, while
+    # sibling imports remain.
+    db = ImportDB('''
+        from base64 import b64decode, b64encode
+        __forget_imports__ = ['from base64 import b64decode']
+    ''')
+    result = db.by_fullname_or_import_as
+    expected = {
+        'base64': (Import('import base64'),),
+        'b64encode': (Import('from base64 import b64encode'),),
+    }
+    assert result == expected
+    assert 'b64decode' not in result
+
+
+def test_ImportDB_by_fullname_or_import_as_forget_prefix_1():
+    # Regression test: forgetting a *prefix* module import while a member
+    # import remains must not leave an empty tuple behind (which used to make
+    # get_known_import()/auto_import_symbol() choke).
+    db = ImportDB('''
+        from base64 import b64encode
+        __forget_imports__ = ['import base64']
+    ''')
+    result = db.by_fullname_or_import_as
+    expected = {
+        'b64encode': (Import('from base64 import b64encode'),),
+    }
+    assert result == expected
+    # In particular the synthesized 'base64' prefix entry must be gone, not
+    # mapped to an empty tuple.
+    assert 'base64' not in result
+    assert () not in result.values()
+
+
 def test_ImportDB_get_default_1():
     db = ImportDB.get_default('.')
     assert isinstance(db, ImportDB)

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1605,6 +1605,64 @@ def test_autoimport_symbol_1():
 
 
 @retry
+def test_autoimport_forget_from_import_1(tmp):
+    # A "from X import Y" listed in a .pyflyby `__forget_imports__` is not
+    # auto-imported (even though the same file makes it a known import), while a
+    # sibling import from the same module is unaffected.
+    writetext(tmp.file,
+              'from base64 import b64decode, b64encode\n'
+              '__forget_imports__ = ["from base64 import b64decode"]\n')
+    ipython("""
+        In [1]: import pyflyby; pyflyby.enable_auto_importer()
+        In [2]: b64decode
+        ---------------------------------------------------------------------------
+        NameError                                 Traceback (most recent call last)
+        ... in ...
+        NameError: name 'b64decode' is not defined
+        In [3]: b64encode(b'koala')
+        [PYFLYBY] from base64 import b64encode
+        Out[3]: b'a29hbGE='
+    """, PYFLYBY_PATH=tmp.file)
+
+
+@retry
+def test_autoimport_forget_pyflyby_path_module_1(tmp):
+    # Regression for the reported scenario: a .pyflyby file that forgets
+    # "import collections" while also providing "from collections import ...".
+    # This used to incorrectly raise AssertionError and disable the auto importer.
+    writetext(tmp.file,
+              'from collections import defaultdict\n'
+              '__forget_imports__ = ["import collections"]\n')
+    ipython("""
+        In [1]: import pyflyby; pyflyby.enable_auto_importer()
+        In [2]: collections
+        ---------------------------------------------------------------------------
+        NameError                                 Traceback (most recent call last)
+        ... in ...
+        NameError: name 'collections' is not defined
+        In [3]: defaultdict(list)['x']
+        [PYFLYBY] from collections import defaultdict
+        Out[3]: []
+    """, PYFLYBY_PATH=tmp.file)
+
+
+@retry
+def test_autoimport_forget_member_access_unaffected(tmp):
+    # Forgetting "from base64 import b64decode" suppresses the bare name
+    # b64decode, but must not affect access via the (separately imported) module
+    # as base64.b64decode.
+    writetext(tmp.file,
+              'from base64 import b64decode\n'
+              '__forget_imports__ = ["from base64 import b64decode"]\n')
+    ipython("""
+        In [1]: import pyflyby; pyflyby.enable_auto_importer()
+        In [2]: import base64
+        In [3]: base64.b64decode(b'eHl6enk=')
+        Out[3]: b'xyzzy'
+    """, PYFLYBY_PATH=tmp.file)
+
+
+@retry
 def test_autoimport_statement_1():
     ipython("""
         In [1]: import pyflyby; pyflyby.enable_auto_importer()
@@ -1936,6 +1994,42 @@ def test_complete_symbol_basic_1():
         [PYFLYBY] from base64 import b64decode
         Out[2]: b'xyzzy'
     """)
+
+
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
+@retry
+def test_complete_symbol_forget_1(tmp):
+    # A symbol listed in a .pyflyby `__forget_imports__` is neither
+    # tab-completed nor auto-imported on Tab. `b64deco<TAB>` therefore does
+    # nothing, and evaluating the (incomplete) name raises NameError.
+    writetext(tmp.file,
+              'from base64 import b64decode\n'
+              '__forget_imports__ = ["from base64 import b64decode"]\n')
+    ipython("""
+        In [1]: import pyflyby; pyflyby.enable_auto_importer()
+        In [2]: b64deco\t
+        In [2]: b64deco
+        ---------------------------------------------------------------------------
+        NameError                                 Traceback (most recent call last)
+        ... in ...
+        NameError: name 'b64deco' is not defined
+    """, PYFLYBY_PATH=tmp.file)
+
+
+@pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')
+@retry
+def test_complete_symbol_forget_other_still_completes_1(tmp):
+    # Forgetting one import does not disable tab completion / auto-import of a
+    # sibling import from the same module.
+    writetext(tmp.file,
+              'from base64 import b64decode, b64encode\n'
+              '__forget_imports__ = ["from base64 import b64decode"]\n')
+    ipython("""
+        In [1]: import pyflyby; pyflyby.enable_auto_importer()
+        In [2]: b64enco\tde(b'llama')
+        [PYFLYBY] from base64 import b64encode
+        Out[2]: b'bGxhbWE='
+    """, PYFLYBY_PATH=tmp.file)
 
 
 @pytest.mark.skipif(_SUPPORTS_TAB_AUTO_IMPORT, reason='Autoimport on Tab requires IPython 9.3+')


### PR DESCRIPTION
- [x] Add tests for both issues (unit + integration)
- [x] Support disabling auto-import for importable modules via `__forget_imports__`
- [x] Fix `__forget_imports__` of a module with a known sub-import crashing the auto-importer with `AssertionError`
