### PR TITLE
Remove functionally dead code.

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -1262,7 +1262,6 @@ class _MissingImportFinder:
     def _visit_Load(self, fullname: str) -> None:
         logger.debug("_visit_Load(%r)", fullname)
         if self._in_FunctionDef:
-            self._visit_Load_defered(fullname)
             # We're in a FunctionDef.  We need to defer checking whether this
             # references undefined names.  The reason is that globals (or
             # stores in a parent function scope) may be stored later.

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -174,7 +174,6 @@ class _LocalImportBlockWrapper:
     importset: ImportSet
     start_lineno: int
     end_lineno: int
-    _original_imports: set[Import]
     _id: str
     _semicolon_suffixes: dict[int, str]
     # The physical (non-import) block whose source text this local import lives
@@ -196,8 +195,6 @@ class _LocalImportBlockWrapper:
         self.transform = transform
         self.start_lineno = start_lineno
         self.end_lineno = end_lineno
-        # Store the original imports so we can detect what was removed
-        self._original_imports = set(transform.importset.imports)
         self._id = hex(id(self))
         self._semicolon_suffixes = semicolon_suffixes
         self.container = container
@@ -212,13 +209,6 @@ class _LocalImportBlockWrapper:
             return f"<_LocalImportBlockWrapper lineno={self.start_lineno} {self.transform!r}>"
         else:
             return f"<_LocalImportBlockWrapper lines={self.start_lineno}-{self.end_lineno} {self.transform!r}>"
-
-    def get_removed_imports(self) -> set[Import]:
-        """Return the set of imports that have been removed from this block."""
-        current_imports = set(self.transform.importset.imports)
-        removed = self._original_imports - current_imports
-        logger.debug("get_removed_imports on block %s: removed=%r", self._id, removed)
-        return removed
 
 class NoImportBlockError(Exception):
     pass
@@ -457,9 +447,6 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         result = [block.pretty_print(params=params) for block in self.blocks]
         output = FileText.concatenate(result)
 
-        # Handle removal of local imports from function/class bodies
-        output = self._remove_local_imports_from_output(output)
-
         # Handle semicolons in import statements
         output = self._split_semicolon_chained_imports(output)
 
@@ -528,121 +515,6 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
                 new_output_lines.append(line)
 
         return FileText("\n".join(new_output_lines))
-
-    def _remove_local_imports_from_output(self, output: FileText) -> FileText:
-        """
-        Post-process the output to remove local imports that have been deleted.
-
-        This is necessary because local imports are embedded in function bodies,
-        which are stored in self.blocks as plain text. When we remove imports from
-        local import blocks, we need to also remove those lines from the output.
-        """
-        # Collect all imports that need to be removed, mapped by line number
-        lines_to_remove = set()
-
-        for block in self.import_blocks:
-            if not isinstance(block, _LocalImportBlockWrapper):
-                continue
-
-            logger.debug(
-                "Checking local block %s at lines %d-%d",
-                block._id,
-                block.start_lineno,
-                block.end_lineno,
-            )
-            removed_imports = block.get_removed_imports()
-            logger.debug("Block %s: Removed imports: %r", block._id, removed_imports)
-
-            if not removed_imports:
-                continue
-
-            logger.debug(
-                "Found %d removed imports in local block at lines %d-%d",
-                len(removed_imports),
-                block.start_lineno,
-                block.end_lineno,
-            )
-
-            # We need to figure out which lines in the output correspond to these imports
-            # The block knows its original line range, so we can map back to the source
-            # For now, we'll use a simple approach: parse the original input text
-            # to find which line each import was on
-
-            # Get the original input text for this block
-            original_lines = str(self.input.text).split("\n")
-
-            # For each removed import, find its line in the original source
-            for imp in removed_imports:
-                logger.debug("Looking for import: %s", imp)
-                # Search for the import statement in the original line range
-                for lineno in range(block.start_lineno, block.end_lineno + 1):
-                    if lineno <= len(original_lines):
-                        line = original_lines[lineno - 1]
-                        # Check if this line contains the import
-                        if self._line_contains_import(line, imp):
-                            logger.debug(
-                                "Found import on line %d: %s", lineno, line.strip()
-                            )
-                            lines_to_remove.add(lineno)
-                            break
-
-        if not lines_to_remove:
-            return output
-
-        logger.debug("Removing lines: %s", sorted(lines_to_remove))
-
-        # Filter out the lines from the output
-        # The output may have been reformatted, so we can't rely on line numbers matching exactly
-        # Instead, we'll filter the output by matching the lines to remove
-        output_lines = str(output).split("\n")
-
-        # Get the actual lines to remove by their content
-        input_lines = str(self.input.text).split("\n")
-        lines_to_remove_content = set()
-        for lineno in lines_to_remove:
-            if lineno <= len(input_lines):
-                # Store the stripped version to match against
-                line_content = input_lines[lineno - 1].strip()
-                if line_content:
-                    lines_to_remove_content.add(line_content)
-
-        logger.debug("Lines to remove by content: %s", lines_to_remove_content)
-
-        # Filter output lines by content match
-        filtered_lines = []
-        for line in output_lines:
-            stripped = line.strip()
-            # Keep the line if it's not in the set of lines to remove
-            if stripped not in lines_to_remove_content or not stripped:
-                filtered_lines.append(line)
-            else:
-                logger.debug("Removing line: %s", line)
-
-        return FileText("\n".join(filtered_lines))
-
-    def _line_contains_import(self, line: str, imp: Import) -> bool:
-        """
-        Check if a line contains the given import statement.
-
-        Parse the line as an import statement and compare Import objects,
-        rather than using string matching which is fragile with spacing.
-        """
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            return False
-
-        try:
-            # Parse the line as an import statement
-            stmt = ImportStatement._from_str(stripped)
-            # Check if any of the imports in this statement match the target import
-            for line_import in stmt.imports:
-                if line_import == imp:
-                    return True
-        except (SyntaxError, ValueError):
-            # Line is not a valid import statement
-            pass
-
-        return False
 
     def find_import_block_by_lineno(self, lineno: int) -> Union[SourceToSourceImportBlockTransformation, _LocalImportBlockWrapper]:
         """

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -776,8 +776,6 @@ class PythonBlock:
             else:
                 assert isinstance(self.ast_node, ast.Module)
                 return self.ast_node
-        elif mode == "exec":
-            raise NotImplementedError
         else:
             raise ValueError("parse(): invalid mode=%r" % (mode,))
 

--- a/tests/test_imports2s_bis.py
+++ b/tests/test_imports2s_bis.py
@@ -349,64 +349,6 @@ def test_tidy_local_imports_with_added_mandatory_import(input_code, expected_cod
 
 
 @pytest.mark.parametrize(
-    "line,import_str,expected",
-    [
-        # Simple imports with variable spacing
-        ("import os", "import os", True),
-        ("import    os", "import os", True),
-        ("  import os  ", "import os", True),
-        ("import os", "import sys", False),
-        # from...import statements
-        ("from os import path", "from os import path", True),
-        ("from    os    import    path", "from os import path", True),
-        ("from os import path", "from sys import path", False),
-        ("from os import path", "from os import sep", False),
-        # Aliased imports
-        ("import os as operating_system", "import os as operating_system", True),
-        ("from os import path as p", "from os import path as p", True),
-        ("from os import path   as   p", "from os import path as p", True),
-        # Multiple imports on one line
-        ("import os, sys", "import os", True),
-        ("import os, sys", "import sys", True),
-        ("import os, sys", "import json", False),
-        # Edge cases
-        ("# import os", "import os", False),
-        ("", "import os", False),
-        ("   ", "import os", False),
-        ("x = import os", "import os", False),
-    ],
-    ids=[
-        "simple_single_space",
-        "simple_multiple_spaces",
-        "simple_with_whitespace",
-        "simple_non_matching",
-        "from_single_space",
-        "from_multiple_spaces",
-        "from_non_matching_module",
-        "from_non_matching_name",
-        "alias_import",
-        "alias_from_import",
-        "alias_multiple_spaces",
-        "multiple_on_line_first",
-        "multiple_on_line_second",
-        "multiple_on_line_non_matching",
-        "edge_case_comment",
-        "edge_case_empty",
-        "edge_case_whitespace_only",
-        "edge_case_non_import",
-    ],
-)
-def test_line_contains_import(line, import_str, expected):
-    """Test _line_contains_import with various import styles and spacing."""
-    from pyflyby._imports2s import SourceToSourceFileImportsTransformation
-    from pyflyby._importstmt import Import
-
-    transformer = SourceToSourceFileImportsTransformation("import sys\n")
-    imp = Import(import_str)
-    assert transformer._line_contains_import(line, imp) == expected
-
-
-@pytest.mark.parametrize(
     ("code", "tidy_local", "expect_present", "expect_absent"),
     [
         pytest.param(

--- a/tests/test_importstmt.py
+++ b/tests/test_importstmt.py
@@ -11,6 +11,7 @@ from   unittest.mock            import patch
 from   pyflyby._flags           import CompilerFlags
 from   pyflyby._format          import FormatParams
 from   pyflyby._importstmt      import (Import, ImportSplit, ImportStatement,
+                                        NonImportStatementError,
                                         read_black_config)
 
 def test_Import_from_parts_1():
@@ -353,3 +354,69 @@ def test_ImportStatement_with_comments(text, comment, should_keep):
             assert comment in comments[0]
         else:
             assert not any(comment in line for line in pretty)
+
+
+@pytest.mark.parametrize(
+    "line,import_str,expected",
+    [
+        # Simple imports with variable spacing
+        ("import os", "import os", True),
+        ("import    os", "import os", True),
+        ("  import os  ", "import os", True),
+        ("import os", "import sys", False),
+        # from...import statements
+        ("from os import path", "from os import path", True),
+        ("from    os    import    path", "from os import path", True),
+        ("from os import path", "from sys import path", False),
+        ("from os import path", "from os import sep", False),
+        # Aliased imports
+        ("import os as operating_system", "import os as operating_system", True),
+        ("from os import path as p", "from os import path as p", True),
+        ("from os import path   as   p", "from os import path as p", True),
+        # Multiple imports on one line
+        ("import os, sys", "import os", True),
+        ("import os, sys", "import sys", True),
+        ("import os, sys", "import json", False),
+    ],
+    ids=[
+        "simple_single_space",
+        "simple_multiple_spaces",
+        "simple_with_whitespace",
+        "simple_non_matching",
+        "from_single_space",
+        "from_multiple_spaces",
+        "from_non_matching_module",
+        "from_non_matching_name",
+        "alias_import",
+        "alias_from_import",
+        "alias_multiple_spaces",
+        "multiple_on_line_first",
+        "multiple_on_line_second",
+        "multiple_on_line_non_matching",
+    ],
+)
+def test_ImportStatement_membership_normalization(line, import_str, expected):
+    """A statement's imports match an Import irrespective of source spacing."""
+    stmt = ImportStatement(line.strip())
+    imp = Import(import_str)
+    assert (imp in stmt.imports) == expected
+
+
+@pytest.mark.parametrize(
+    "line,exc",
+    [
+        ("# import os", NonImportStatementError),
+        ("", NonImportStatementError),
+        ("   ", NonImportStatementError),
+        ("x = import os", SyntaxError),
+    ],
+    ids=[
+        "comment",
+        "empty",
+        "whitespace_only",
+        "non_import",
+    ],
+)
+def test_ImportStatement_rejects_non_imports(line, exc):
+    with raises(exc):
+        ImportStatement(line)


### PR DESCRIPTION
While called there is other mecanism that do remove all imports so this functionally never remove anything; or more precisely only run on code that has nothing to remove.