### PR TITLE
xreload: rebind __globals__ of methods/functions added by a reload gh#30 `Prop#219646`

### DIFF
--- a/lib/python/pyflyby/_livepatch.py
+++ b/lib/python/pyflyby/_livepatch.py
@@ -317,6 +317,14 @@ def livepatch(old: Any, new: Any, modname: Optional[str] = None,
     return result
 
 
+# Sentinel cache key under which we record a mapping from
+# ``id(new_module.__dict__)`` to the corresponding live (old) module
+# ``__dict__``.  This is used to rebind the ``__globals__`` of functions that
+# are newly introduced by a reload (see ``_rebind_new_object``).  A string key
+# never collides with the ``(id(old), id(new))`` tuple keys used elsewhere.
+_GLOBALS_REBIND_KEY = "__pyflyby_globals_rebind__"
+
+
 def _livepatch__module(old_mod: types.ModuleType, new_mod: types.ModuleType,
                        modname: Optional[str],
                        cache: Dict[Tuple[int, int], Any],
@@ -324,11 +332,55 @@ def _livepatch__module(old_mod: types.ModuleType, new_mod: types.ModuleType,
     """
     Livepatch a module.
     """
+    # Record that functions whose ``__globals__`` is the scratch module's dict
+    # (i.e. functions defined by the newly-executed module) should be rebound
+    # to the live module's dict when they are newly introduced.  Without this,
+    # a function added by a reload -- e.g. a new method on an existing class --
+    # would keep referencing the throwaway scratch namespace, so its module and
+    # global references would go stale on subsequent reloads.  See GH #30.
+    cache.setdefault(_GLOBALS_REBIND_KEY, {})[  # type: ignore[call-overload]
+        id(new_mod.__dict__)] = old_mod.__dict__
     result = livepatch(old_mod.__dict__, new_mod.__dict__,
                        modname=modname,
                        cache=cache, visit_stack=visit_stack)
     assert result is old_mod.__dict__
     return old_mod
+
+
+def _rebind_new_object(obj: Any,
+                       cache: Dict[Tuple[int, int], Any]) -> Any:
+    """
+    Given an object that is being newly introduced into the target namespace by
+    a reload, return a version whose function ``__globals__`` reference the live
+    module dict rather than the throwaway scratch module dict.
+
+    This applies to plain functions as well as functions wrapped in
+    ``staticmethod``/``classmethod``.  Any other object (or a function that was
+    imported from a different module, and thus references some other module's
+    dict) is returned unchanged.
+    """
+    mapping = cache.get(_GLOBALS_REBIND_KEY)  # type: ignore[call-overload]
+    if not mapping:
+        return obj
+    if isinstance(obj, (staticmethod, classmethod)):
+        rebound = _rebind_new_object(obj.__func__, cache)
+        if rebound is obj.__func__:
+            return obj
+        return type(obj)(rebound)
+    if not isinstance(obj, types.FunctionType):
+        return obj
+    target = mapping.get(id(obj.__globals__))
+    if target is None or obj.__globals__ is target:
+        return obj
+    newfunc = types.FunctionType(
+        obj.__code__, target, obj.__name__,
+        obj.__defaults__, obj.__closure__)
+    newfunc.__dict__.update(obj.__dict__)
+    newfunc.__kwdefaults__ = obj.__kwdefaults__
+    newfunc.__qualname__ = obj.__qualname__
+    newfunc.__annotations__ = obj.__annotations__
+    newfunc.__doc__ = obj.__doc__
+    return newfunc
 
 
 def _livepatch__dict(old_dict: Dict[Any, Any], new_dict: Dict[Any, Any],
@@ -342,7 +394,7 @@ def _livepatch__dict(old_dict: Dict[Any, Any], new_dict: Dict[Any, Any],
     newnames = set(new_dict)
     # Add newly introduced names.
     for name in newnames - oldnames:
-        old_dict[name] = new_dict[name]
+        old_dict[name] = _rebind_new_object(new_dict[name], cache)
     # Delete names that are no longer current.
     for name in oldnames - newnames:
         del old_dict[name]
@@ -488,7 +540,7 @@ def _livepatch__class(oldclass: type, newclass: type,
     for name in oldnames - newnames:
         delattr(oldclass, name)
     for name in newnames - oldnames:
-        setattr(oldclass, name, newdict[name])
+        setattr(oldclass, name, _rebind_new_object(newdict[name], cache))
     oldclass.__bases__ = newclass.__bases__
     names = oldnames & newnames
     names.difference_update(olddict.get("__slots__", []))

--- a/tests/test_livepatch.py
+++ b/tests/test_livepatch.py
@@ -334,6 +334,61 @@ def test_xreload_method_1(tpp):
     assert x.applegate() == 502
 
 
+def test_xreload_add_method_globals_1(tpp):
+    """
+    GH #30: A method added by a reload should reference module-level globals
+    (e.g. imported modules) via the live module namespace, not the throwaway
+    scratch namespace.  Otherwise it would go stale on subsequent reloads.
+    """
+    writetext(
+        tpp / "xreload_add_method.py",
+        """
+        VALUE = 1
+        class MyClass(object):
+            def existing(self):
+                return VALUE
+    """,
+    )
+    from xreload_add_method import MyClass
+
+    obj = MyClass()
+    # Add a new method that references the same module-level global, and bump
+    # VALUE.
+    writetext(
+        tpp / "xreload_add_method.py",
+        """
+        VALUE = 2
+        class MyClass(object):
+            def existing(self):
+                return VALUE
+            def added(self):
+                return VALUE
+    """,
+    )
+    xreload("xreload_add_method")
+    assert obj.existing() == 2
+    assert obj.added() == 2
+    # The new method's __globals__ must be the live module dict, so that a
+    # later reload updates what it sees.
+    import xreload_add_method as m
+    assert obj.added.__func__.__globals__ is m.__dict__
+    # Bump VALUE again; both the pre-existing and the added method must see it.
+    writetext(
+        tpp / "xreload_add_method.py",
+        """
+        VALUE = 3
+        class MyClass(object):
+            def existing(self):
+                return VALUE
+            def added(self):
+                return VALUE
+    """,
+    )
+    xreload("xreload_add_method")
+    assert obj.existing() == 3
+    assert obj.added() == 3
+
+
 def test_xreload_method_saved_1(tpp):
     # Verify that xreload works on existing references to methods.
     writetext(tpp/"treaty86420758.py", """


### PR DESCRIPTION
When xreload adds a name that didn't exist before (e.g. a new method on an existing class, or a new module-level function), it copied the object verbatim from the throwaway scratch module used to exec the new source.  For functions this meant __globals__ kept pointing at the scratch namespace instead of the live module dict, so their module/global references went stale on subsequent reloads while pre-existing methods stayed correct.

Record a mapping from the scratch module dict to the live module dict and, when introducing a new function (including staticmethod/classmethod wrappers), rebuild it bound to the live module globals.

Fixes #30.