### PR TITLE
load_symbol: add opt-in allow_eval to evaluate expressions

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -2451,7 +2451,8 @@ class LoadSymbolError(Exception):
 def load_symbol(fullname: str,
                 namespaces: Union[ScopeStack, Dict[str, Any], List[Dict[str, Any]]],
                 autoimport: bool = False, db: Any = None,
-                autoimported: Optional[Dict[DottedIdentifier, bool]] = None) -> Any:
+                autoimported: Optional[Dict[DottedIdentifier, bool]] = None,
+                allow_eval: bool = False) -> Any:
     """
     Load the symbol ``fullname``.
 
@@ -2469,10 +2470,19 @@ def load_symbol(fullname: str,
     ...
     pyflyby._autoimp.LoadSymbolError: os.path.join: NameError: os
 
+    By default ``fullname`` must be a plain dotted name, which is resolved by
+    attribute access.  With ``allow_eval=True``, ``fullname`` may instead be an
+    arbitrary expression (with function calls, subscripts, etc.), which is
+    evaluated against ``namespaces``.
+
+    >>> load_symbol("os.path.join('a', 'b')[0].upper()", {"os": os}, allow_eval=True)
+    'A'
+
     :type fullname:
       ``str``
     :param fullname:
-      Fully-qualified symbol name, e.g. "os.path.join".
+      Fully-qualified symbol name, e.g. "os.path.join".  If ``allow_eval`` is
+      true, this may also be an arbitrary expression, e.g. "os.getcwd()".
     :type namespaces:
       ``dict`` or ``list`` of ``dict``
     :param namespaces:
@@ -2490,12 +2500,33 @@ def load_symbol(fullname: str,
       dictionary, and will add attempted symbols to this dictionary, with
       value ``True`` if the autoimport succeeded, or ``False`` if the autoimport
       did not succeed.
+    :param allow_eval:
+      If ``False`` (default), ``fullname`` must be a plain dotted name resolved
+      by attribute access.  If ``True``, then when ``fullname`` is not a plain
+      dotted name (i.e. it contains calls, subscripts, operators, etc.), it is
+      evaluated as a Python expression against ``namespaces`` instead.
     :return:
       Object.
     :raise LoadSymbolError:
       Object was not found or there was another exception.
     """
     namespaces = ScopeStack(namespaces)
+    if allow_eval and not all(
+            part.isidentifier() for part in fullname.split(".")):
+        # ``fullname`` is an expression (function call, subscript, operator,
+        # ...), not a plain dotted name.  Evaluate it against the namespaces,
+        # optionally auto-importing any missing names first.
+        global_ns, local_ns = namespaces.merged_to_two()
+        try:
+            if autoimport:
+                return auto_eval(fullname, globals=global_ns, locals=local_ns,
+                                 db=db)
+            return eval(compile(fullname, "<load_symbol>", "eval"),
+                        global_ns, local_ns)
+        except Exception as e:
+            e2 = LoadSymbolError(fullname)
+            e2.__cause__ = e
+            raise e2
     if autoimport:
         # Auto-import the symbol first.
         # We do the lookup as a separate step after auto-import.  (An

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -1977,24 +1977,18 @@ def test_load_symbol_missing_2():
         load_symbol("os.path.join", {})
 
 
-@pytest.mark.xfail(
-    strict=True, reason="old test that was not names with test_ and never passed"
-)
 def test_load_symbol_eval_1():
-    assert 'a/b' == load_symbol("os.path.join('a','b')", {"os": os})
-    assert '/'   == load_symbol("os.path.join('a','b')[1]", {"os": os})
-    assert 'A'   == load_symbol("os.path.join('a','b')[0].upper()", {"os": os})
+    assert 'a/b' == load_symbol("os.path.join('a','b')", {"os": os}, allow_eval=True)
+    assert '/'   == load_symbol("os.path.join('a','b')[1]", {"os": os}, allow_eval=True)
+    assert 'A'   == load_symbol("os.path.join('a','b')[0].upper()", {"os": os}, allow_eval=True)
 
 
-@pytest.mark.xfail(
-    strict=True, reason="old test that was not names with test_ and never passed"
-)
 def test_load_symbol_eval_2(capsys):
     assert '/' == load_symbol("(os.path.sep[0])", {}, autoimport=True,
                               allow_eval=True)
     out, _ = capsys.readouterr()
     expected = dedent("""
-        [PYFLYBY] import os
+        [PYFLYBY] import os.path
     """).lstrip()
     assert expected == out
 
@@ -2021,32 +2015,26 @@ def test_load_symbol_wrap_exc_1():
         assert False
 
 
-@pytest.mark.xfail(
-    strict=True, reason="old test that was not names with test_ and never passed"
-)
 def test_load_symbol_wrap_exc_eval_1():
     def foo31617859():
         return 1 / 0
 
-    ns = [{"foo": foo31617859()}]
+    ns = [{"foo": foo31617859}]
     try:
-        load_symbol("foo()", ns, auto_eval=True)
+        load_symbol("foo()", ns, allow_eval=True)
     except LoadSymbolError as e:
         assert type(e.__cause__) == ZeroDivisionError
     else:
         assert False
 
 
-@pytest.mark.xfail(
-    strict=True, reason="old test that was not names with test_ and never passed"
-)
 def test_load_symbol_wrap_exc_eval_getattr_1():
     class Foo15356301(object):
         def __getattr__(self, k):
             1/0
     ns = [{"foo": Foo15356301()}]
     try:
-        load_symbol("foo.bar", ns, auto_eval=True)
+        load_symbol("foo.bar", ns, allow_eval=True)
     except LoadSymbolError as e:
         assert type(e.__cause__) == ZeroDivisionError
     else:


### PR DESCRIPTION
load_symbol() previously only resolved a plain dotted name (e.g. "os.path.join") via attribute traversal.  Add an opt-in `allow_eval` parameter: when set and the name is not a plain dotted identifier (i.e. it contains calls, subscripts, operators, ...), evaluate it as a Python expression against the namespaces instead, optionally auto-importing missing names first.

The eval path reuses the existing machinery: ScopeStack.merged_to_two() supplies (globals, locals), and auto_eval() handles the autoimport case (printing "[PYFLYBY] import ..." as usual).  Any exception during evaluation is wrapped in LoadSymbolError with __cause__ set, matching the existing contract.  Plain dotted names still take the original getattr path, so default behavior is unchanged.

This revives four load_symbol eval tests that were marked xfail("old test that was not names with test_ and never passed") because they exercised an eval feature that never actually existed.  Fix them up to match the real API:

  - test_load_symbol_eval_1: add allow_eval=True.  It previously passed no flag, which made it directly contradict the passing test_load_symbol_no_eval_1 (same call, expects LoadSymbolError), so it could never have passed.
  - test_load_symbol_wrap_exc_eval_1: rename the nonexistent auto_eval= kwarg to allow_eval=, and fix a bug where {"foo": foo31617859()} invoked the function immediately instead of passing the function object.
  - test_load_symbol_wrap_exc_eval_getattr_1: rename auto_eval= to allow_eval=.
  - test_load_symbol_eval_2: update stale expected log from "import os" to the correct, more precise "import os.path".