### PR TITLE
Support autocompletion in `ipdb.set_trace()` and `breakpoint()` in addition to `%debug`

### DIFF
--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -1646,8 +1646,27 @@ class AutoImporter:
                 else:
                     with AdviceCtx(TerminalPdb.__init__, TerminalPdb_with_autoimport):
                         yield
-        iptb = getattr(ip, "InteractiveTB", None)
         ok = True
+
+        @self._advise(sys.breakpointhook)
+        def breakpoint_debugger_with_autoimport(*args, **kwargs):
+            with HookPdbCtx():
+                return __original__(*args, **kwargs)
+
+        try:
+            import ipdb
+
+            if hasattr(ipdb, "set_trace"):
+                @self._advise((ipdb, "set_trace"))
+                def ipdb_debugger_with_autoimport(*args, **kwargs):
+                    with HookPdbCtx():
+                        return __original__(*args, **kwargs)
+            else:
+                ok = False
+        except ModuleNotFoundError:
+            pass
+
+        iptb = getattr(ip, "InteractiveTB", None)
         if hasattr(iptb, "debugger"):
             # Hook ip.InteractiveTB.debugger().  This implements auto
             # importing for "%debug" (postmortem mode).

--- a/lib/python/pyflyby/_util.py
+++ b/lib/python/pyflyby/_util.py
@@ -309,7 +309,7 @@ class Aspect(object):
         while hasattr(joinpoint, "__joinpoint__"):
             joinpoint = joinpoint.__joinpoint__
         self._joinpoint = joinpoint
-        if (isinstance(joinpoint, (types.FunctionType, type))
+        if (isinstance(joinpoint, (types.FunctionType, types.BuiltinFunctionType, type))
             and not (joinpoint.__name__ != joinpoint.__qualname__)):
             self._qname = "%s.%s" % (
                 joinpoint.__module__,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ test = [
     'coverage',
     'flaky',
     'hypothesis',
+    'ipdb',
     'ipykernel>=5.4.3',
     'ipython>=8',
     'jupyter',

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -3829,6 +3829,52 @@ def test_debug_auto_import_statement_step_1(frontend, tmp):
 # unimportable.
 
 
+debugger_activations = [
+    "breakpoint()",
+    "import ipdb; ipdb.set_trace()",
+    "%debug pass"
+]
+
+@retry
+@pytest.mark.parametrize("enter_debugger", debugger_activations)
+def test_breakpoint_baseline_1(enter_debugger, frontend):
+    # Verify that we can test breakpoint without any pyflyby involved.
+    ipython(f"""
+        In [1]: {enter_debugger}
+        ....
+        ipdb> p 43405728 + 69642968
+        113048696
+        ipdb> q
+    """, frontend=frontend)
+
+
+@retry
+@pytest.mark.parametrize("enter_debugger", debugger_activations)
+def test_breakpoint_without_autoimport_1(enter_debugger, frontend):
+    # Verify that without autoimport, we get a NameError.
+    ipython(f"""
+        In [1]: {enter_debugger}
+        ....
+        ipdb> p b64decode("QXVkdWJvbg==")
+        *** NameError: name 'b64decode' is not defined
+        ipdb> q
+    """, frontend=frontend)
+
+
+@retry
+@pytest.mark.parametrize("enter_debugger", debugger_activations)
+def test_breakpoint_auto_import_p_1(enter_debugger, frontend):
+    ipython(f"""
+        In [1]: import pyflyby; pyflyby.enable_auto_importer()
+        In [2]: {enter_debugger}
+        ....
+        ipdb> p b64decode("S2Vuc2luZ3Rvbg==")
+        [PYFLYBY] from base64 import b64decode
+        b'Kensington'
+        ipdb> q
+    """, frontend=frontend)
+
+
 @pytest.mark.skipif(
     (3, 14, 1) <= sys.version_info[:3] <= (3, 14, 5),
     reason="linux + >=3.14.1 show some extra stacks.",


### PR DESCRIPTION
- [x] Add tests for variants of debugger activation, including autocompletion
- [x] Activate the completer hooks in more contexts