### PR TITLE
Revert cleanup of unused items

### DIFF
--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -283,6 +283,7 @@ from __future__ import print_function
 import ast
 import builtins
 from   contextlib               import contextmanager
+from   functools                import total_ordering
 import inspect
 import logging
 import os
@@ -312,7 +313,7 @@ from   pyflyby._interactive     import (get_ipython_terminal_app_with_autoimport
 from   pyflyby._log             import logger
 from   pyflyby._modules         import ModuleHandle
 from   pyflyby._parse           import PythonBlock
-from   pyflyby._util            import indent, prefixes
+from   pyflyby._util            import cmp, indent, prefixes
 
 # TODO: add --tidy-imports, etc
 
@@ -1047,6 +1048,7 @@ def auto_apply(function, commandline_args, namespace, arg_mode=None,
         _handle_user_exception()
 
 
+@total_ordering
 class LoggedList:
     """
     Read-only list proxy that tracks which items have not yet been accessed.
@@ -1056,41 +1058,143 @@ class LoggedList:
     supported (subscript, iterate, len, repr/str).
     """
 
+    _ACCESSED = object()
+
     def __init__(self, items):
         self._items = list(items)
-        self._accessed = [False] * len(self._items)
+        self._unaccessed = list(self._items)
 
-    def _mark_accessed(self, idx):
-        if isinstance(idx, slice):
-            for i in range(*idx.indices(len(self._items))):
-                self._accessed[i] = True
-        else:
-            self._accessed[idx] = True
+    def append(self, x):
+        self._unaccessed.append(self._ACCESSED)
+        self._items.append(x)
+
+    def count(self):
+        return self._items.count()
+
+    def extend(self, new_items):
+        new_items = list(new_items)
+        self._unaccessed.extend([self._ACCESSED] * len(new_items))
+        self._items.extend(new_items)
+
+    def index(self, x, *start_stop):
+        index = self._items.index(x, *start_stop) # may raise ValueError
+        self._unaccessed[index] = self._ACCESSED
+        return index
+
+    def insert(self, index, x):
+        self._unaccessed.insert(index, self._ACCESSED)
+        self._items.insert(index, x)
+
+    def pop(self, index):
+        self._unaccessed.pop(index)
+        return self._items.pop(index)
+
+    def remove(self, x):
+        index = self._items.index(x)
+        self.pop(index)
+
+    def reverse(self):
+        self._items.reverse()
+        self._unaccessed.reverse()
+
+    def sort(self):
+        indexes = range(len(self._items))
+        indexes.sort(key=self._items.__getitem__) # argsort
+        self._items = [self._items[i] for i in indexes]
+        self._unaccessed = [self._unaccessed[i] for i in indexes]
+
+    def __add__(self, other):
+        return self._items + other
+
+    def __contains__(self, x):
+        try:
+            self.index(x)
+            return True
+        except ValueError:
+            return False
+
+    def __delitem__(self, x):
+        del self._items[x]
+        del self._unaccessed[x]
+
+    def __eq__(self, other):
+        if not isinstance(other, LoggedList):
+            return NotImplemented
+        return self._items == other._items
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    # The rest are defined by total_ordering
+    def __lt__(self, other):
+        if not isinstance(other, LoggedList):
+            return NotImplemented
+        return self._items < other._items
+
+    def __cmp__(self, x):
+        return cmp(self._items, x)
 
     def __getitem__(self, idx):
         result = self._items[idx]
-        self._mark_accessed(idx)
+        if isinstance(idx, slice):
+            self._unaccessed[idx] = [self._ACCESSED]*len(result)
+        else:
+            self._unaccessed[idx] = self._ACCESSED
         return result
 
+    def __hash__(self):
+        raise TypeError("unhashable type: 'LoggedList'")
+
+    def __iadd__(self, x):
+        self.extend(x)
+
+    def __imul__(self, n):
+        self._items *= n
+        self._unaccessed *= n
+
     def __iter__(self):
+        # Todo: detect mutation while iterating.
         for i, x in enumerate(self._items):
-            self._accessed[i] = True
+            self._unaccessed[i] = self._ACCESSED
             yield x
 
     def __len__(self):
         return len(self._items)
 
+
+    def __mul__(self, n):
+        return self._items * n
+
+    def __reduce__(self):
+        return
+
     def __repr__(self):
-        self._accessed = [True] * len(self._items)
+        self._unaccessed[:] = [self._ACCESSED]*len(self._unaccessed)
         return repr(self._items)
 
+    def __reversed__(self):
+        # Todo: detect mutation while iterating.
+        for i in reversed(range(len(self._items))):
+            self._unaccessed[i] = self._ACCESSED
+            yield self._items[i]
+
+    def __rmul__(self, n):
+        return self._items * n
+
+    def __setitem__(self, idx, value):
+        self._items[idx] = value
+        if isinstance(idx, slice):
+            self._unaccessed[idx] = [self._ACCESSED]*len(value)
+        else:
+            self._unaccessed[idx] = value
+
     def __str__(self):
-        self._accessed = [True] * len(self._items)
+        self._unaccessed[:] = [self._ACCESSED]*len(self._unaccessed)
         return str(self._items)
 
     @property
     def unaccessed(self):
-        return [x for x, used in zip(self._items, self._accessed) if not used]
+        return [x for x in self._unaccessed if x is not self._ACCESSED]
 
 
 @contextmanager


### PR DESCRIPTION
Partially revert #493

Some of those are actually used, try for example:

> py -c 'import sys; print(sys.argv.index("--flag"))' --flag value

We need to make sure LoggedList implements all Features of lists as sys.argv is a list, and programs accessing sys.argv can do any operatoin on it that they will do on a list,

Some of the operation (`.count()`, `.pop()`) are broken, but that should be a separate issue where we track the compliance of `LoggedList` with `list`