### PR TITLE
Wrap over-long imports without emitting invalid syntax

### DIFF
--- a/lib/python/pyflyby/_format.py
+++ b/lib/python/pyflyby/_format.py
@@ -175,6 +175,14 @@ def pyfill(prefix: str, tokens: Sequence[str], params: FormatParams = FormatPara
             # Output looks like:
             #   from foo import abc, defgh, ijkl, mnopq, rst
             return prefix + ", ".join(tokens) + "\n"
+        if len(tokens) == 1:
+            # Nothing to break on, so parens only help if the indented line
+            # fits; else they'd just make the line longer.
+            token = tokens[0]
+            if (params.hanging_indent == "always"
+                    or params.indent + len(token) + 1 <= max_line_length):
+                return prefix + "(\n" + " " * params.indent + token + ")\n"
+            return prefix + token + "\n"
         if params.hanging_indent == "never":
             hanging_indent = False
         elif params.hanging_indent == "always":
@@ -215,4 +223,5 @@ def pyfill(prefix: str, tokens: Sequence[str], params: FormatParams = FormatPara
             return fill(tokens, max_line_length=max_line_length,
                         prefix=(pprefix, " " * len(pprefix)), suffix=("", ")"))
     else:
-        raise NotImplementedError
+        # Parens aren't allowed, so we can only emit one long line.
+        return prefix + ", ".join(tokens) + "\n"

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -599,10 +599,14 @@ class ImportStatement:
         ``# tidy-imports: ignore-import`` survive reformatting even when the
         import wraps onto a backslash continuation.
 
-        :type params:
-          `FormatParams`
-        :param modulename_ljust:
-          Number of characters to left-justify the 'from' name.
+        :param params:
+          Formatting parameters.  Callers typically pass an
+          `ImportFormatParams`.
+        :param import_column:
+          Column at which to line up the 'import' keyword, or ``None`` to not
+          align it.
+        :param from_spaces:
+          Number of spaces after the 'from' keyword.  (Must be at least 1.)
         :rtype:
           ``str``
         """
@@ -632,7 +636,11 @@ class ImportStatement:
                 t = "%s" % (importname,)
 
             tokens.append(t)
-        res = s0 + pyfill(s, tokens, params=params)
+        # Neither ``import (foo)`` nor ``from foo import (*)`` parses.
+        fill_params: FormatParams = params
+        if self.fromname is None or tokens == ["*"]:
+            fill_params = params.replace(wrap_paren=False)
+        res = s0 + pyfill(s, tokens, params=fill_params)
 
         comment = self.get_valid_comment()
         if comment is not None:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -7,6 +7,8 @@
 
 from   textwrap                 import dedent
 
+import pytest
+
 from   pyflyby._format          import FormatParams, fill, pyfill
 
 
@@ -122,3 +124,29 @@ def test_pyfill_hanging_indent_auto_no_1():
                                                 z1, z2)
     """).lstrip()
     assert result == expected
+
+
+@pytest.mark.parametrize("hanging_indent", ['never', 'always', 'auto'])
+@pytest.mark.parametrize("token, expected", [
+    # Issue #135: own indented line, not parens on an over-long one.
+    ('random_teststu as random_my_testtu_foox',
+     'from fooxxxx.barxxxxxx.bazxxx import (\n'
+     '    random_teststu as random_my_testtu_foox)\n'),
+    # Not even an indented line fits, so no parens at all.
+    ('x' * 100,
+     'from fooxxxx.barxxxxxx.bazxxx import ' + 'x' * 100 + '\n'),
+])
+def test_pyfill_single_token_1(token, expected, hanging_indent):
+    if hanging_indent == 'always':
+        # 'always' keeps the parens even when they don't help.
+        expected = ('from fooxxxx.barxxxxxx.bazxxx import (\n'
+                    '    ' + token + ')\n')
+    params = FormatParams(max_line_length=60, hanging_indent=hanging_indent)
+    assert pyfill('from fooxxxx.barxxxxxx.bazxxx import ', [token],
+                  params) == expected
+
+
+def test_pyfill_no_wrap_paren_1():
+    params = FormatParams(max_line_length=20, wrap_paren=False)
+    assert pyfill('import ', ['foo as bar']) == 'import foo as bar\n'
+    assert pyfill('import ', ['x' * 30], params) == 'import ' + 'x' * 30 + '\n'

--- a/tests/test_importstmt.py
+++ b/tests/test_importstmt.py
@@ -4,6 +4,8 @@
 # http://creativecommons.org/publicdomain/zero/1.0/
 
 
+import ast
+
 import pytest
 from   pytest                   import raises
 from   unittest.mock            import patch
@@ -420,3 +422,13 @@ def test_ImportStatement_membership_normalization(line, import_str, expected):
 def test_ImportStatement_rejects_non_imports(line, exc):
     with raises(exc):
         ImportStatement(line)
+
+
+@pytest.mark.parametrize("src", [
+    'import ' + 'a' * 66 + ' as bcde',
+    'from ' + 'q' * 70 + ' import *',
+])
+def test_pretty_print_unparenthesizable_1(src):
+    result = ImportStatement(src).pretty_print(FormatParams(max_line_length=79))
+    assert result == src + "\n"
+    ast.parse(result)


### PR DESCRIPTION
An import statement too long for max_line_length was parenthesized even when that neither helped nor parsed:

    from fooxxxx.barxxxxxx.bazxxx import (random_teststu as random_foox)
    import (aaaa...aaa as bcde)
    from foooo...ooo import (*)

A lone token has nothing to break on, so pyfill now puts it on its own indented line when that fits under the limit, and leaves it unwrapped when it doesn't -- parens would only make the line longer.  Since hanging_indent='always' asks for the parens regardless, honor that.

Parens are also only legal for a `from ... import` of named symbols, so pretty_print asks pyfill not to add them for a plain `import` or a star import; pyfill's wrap_paren=False branch, until now a bare NotImplementedError, emits a single unwrapped line.

Fixes #135