### PR TITLE
Fix test due to upstream change in cpython

### DIFF
--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -1070,14 +1070,8 @@ def test_function_source_variants_1(cmdline):
     assert "binascii.b2a_base64" in output
 
 
-def test_module_help_1():
-    output, retcode = py("base64?")
-    assert retcode == 0
-    assert "RFC 3548" in output
-    assert "import binascii" not in output
-
-
 @pytest.mark.parametrize("args", [
+    "base64?",
     "base64 --help",
     "base64 -help",
     "base64 --h",
@@ -1099,7 +1093,13 @@ def test_module_help_1():
 def test_module_help_variants_1(args):
     output, retcode = py(args.split())
     assert retcode == 0
-    assert "RFC 3548" in output, output
+    # https://github.com/python/cpython/pull/151275,
+    # backported to some 3.14 and 3.13 versions, so conditiona checks until we
+    # support only 3.15+
+    if sys.version_info >= (3,15):
+        assert "RFC 4648" in output
+    else:
+        assert ("RFC 4648" in output) or ('RFC 3548' in output), output
     assert "import binascii" not in output
 
 


### PR DESCRIPTION
python/cpython#151275, changes the docstring, and backport it to some version of Python 3.13 and 3.14 (i belive somehting like 3.13.16 and 3.14.6), so test accordingly.

We conditionally test on 3.15+ to be able to clean up the branches once we drop 3.14 in a few years.