### PR TITLE
Make FormatParams a frozen dataclass

### DIFF
--- a/lib/python/pyflyby/_format.py
+++ b/lib/python/pyflyby/_format.py
@@ -4,44 +4,66 @@
 
 from __future__ import annotations, print_function
 
+import dataclasses
+from   dataclasses              import dataclass, fields
+import sys
 from   typing                   import Any, Optional, Sequence, Tuple, Union
 
+if sys.version_info < (3, 12):
+    from typing_extensions          import Self
+else:
+    from typing import Self
 
-class FormatParams(object):
-    max_line_length: Optional[int] = None
+
+@dataclass(frozen=True)
+class FormatParams:
+    max_line_length: Union[int, float, None] = None
     max_line_length_default: int = 79
     wrap_paren: bool = True
     indent: int = 4
     hanging_indent: str = 'never'
     use_black: bool = False
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> FormatParams:
-        if not kwargs and len(args) == 1 and isinstance(args[0], cls):
-            return args[0]
-        self = object.__new__(cls)
-        # TODO: be more careful here
-        dicts = []
-        for arg in args:
-            if arg is None:
-                pass
-            elif isinstance(arg, cls) or hasattr(self, "__dict__"):
-                dicts.append(arg.__dict__)
-            else:
-                raise TypeError(
-                    "expected None, or instance of %s cls, got %s" % (cls, arg)
-                )
-        if kwargs:
-            dicts.append(kwargs)
-        for kwargs in dicts:
-            for key, value in kwargs.items():
-                if hasattr(self, key):
-                    setattr(self, key, value)
-                else:
-                    raise ValueError("bad kwarg %r" % (key,))
-        return self
+    @classmethod
+    def coerce(cls, arg: Optional[FormatParams] = None) -> Self:
+        """
+        Return ``arg`` as an instance of ``cls``.
+
+          >>> FormatParams.coerce(None)
+          <FormatParams {}>
+
+        ``arg`` may be ``None``, or any `FormatParams`; parameters that
+        ``cls`` does not have are dropped.
+        """
+        if arg is None:
+            return cls()
+        if not isinstance(arg, FormatParams):
+            raise TypeError("expected None or a FormatParams, got %s"
+                            % (type(arg).__name__,))
+        names = {f.name for f in fields(cls)}
+        return cls(**{f.name: getattr(arg, f.name) for f in fields(arg)
+                      if f.name in names})
+
+    def replace(self, **kwargs: Any) -> Self:
+        """
+        Return a copy of ``self`` with the given parameters overridden.
+
+          >>> FormatParams(max_line_length=20).replace(wrap_paren=False)
+          <FormatParams {'max_line_length': 20, 'wrap_paren': False}>
+
+        The result has the same class as ``self``, so subclass-only parameters
+        are preserved.
+        """
+        return dataclasses.replace(self, **kwargs)
 
     def __repr__(self) -> str:
-        return f'<{self.__class__.__name__} {self.__dict__}>'
+        """
+        Show only non-default parameters; the generated dataclass repr
+        would spell out every one of them.
+        """
+        nondefault = {f.name: getattr(self, f.name) for f in fields(self)
+                      if getattr(self, f.name) != f.default}
+        return f'<{self.__class__.__name__} {nondefault}>'
 
 
 def fill(
@@ -50,7 +72,7 @@ def fill(
     prefix: Union[str, Tuple[str, str]] = "",
     suffix: Union[str, Tuple[str, str]] = "",
     newline: str = "\n",
-    max_line_length: int = 80,
+    max_line_length: Union[int, float] = 80,
 ) -> str:
     r"""
     Given a sequences of strings, fill them into a single string with up to
@@ -137,6 +159,7 @@ def pyfill(prefix: str, tokens: Sequence[str], params: FormatParams = FormatPara
     :rtype:
       ``str``
     """
+    max_line_length: Union[int, float]
     if params.max_line_length is None:
         max_line_length = params.max_line_length_default
     else:

--- a/lib/python/pyflyby/_importclns.py
+++ b/lib/python/pyflyby/_importclns.py
@@ -10,6 +10,7 @@ from   collections              import defaultdict
 from   functools                import total_ordering
 
 from   pyflyby._flags           import CompilerFlags
+from   pyflyby._format          import FormatParams
 from   pyflyby._idents          import dotted_prefixes, is_identifier
 from   pyflyby._importstmt      import (Import, ImportFormatParams,
                                         ImportStatement,
@@ -412,18 +413,18 @@ class ImportSet:
 
     def pretty_print(
         self,
-        params: Optional[ImportFormatParams] = None,
+        params: Optional[FormatParams] = None,
         allow_conflicts: bool = False,
     ) -> str:
         """
         Pretty-print a block of import statements into a single string.
 
         :type params:
-          `ImportFormatParams`
+          `FormatParams`
         :rtype:
           ``str``
         """
-        params = ImportFormatParams(params)
+        params = ImportFormatParams.coerce(params)
         # TODO: instead of complaining about conflicts, just filter out the
         # shadowed imports at construction time.
         if not allow_conflicts and self.conflicting_imports:

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -10,6 +10,7 @@ from   contextlib               import nullcontext
 from   pyflyby._autoimp         import scan_for_import_issues
 from   pyflyby._file            import FileText, Filename
 from   pyflyby._flags           import CompilerFlags
+from   pyflyby._format          import FormatParams
 from   pyflyby._importclns      import ImportMap, ImportSet, NoSuchImportError
 from   pyflyby._importdb        import ImportDB
 from   pyflyby._importstmt      import (Import, ImportFormatParams,
@@ -106,10 +107,12 @@ class SourceToSourceTransformationBase:
     def preprocess(self) -> None:
         pass
 
-    def pretty_print(self, params: Any = None) -> Union[FileText, str]:
+    def pretty_print(
+        self, params: Optional[FormatParams] = None
+    ) -> Union[FileText, str]:
         raise NotImplementedError
 
-    def output(self, params: Any = None) -> PythonBlock:
+    def output(self, params: Optional[FormatParams] = None) -> PythonBlock:
         """
         Pretty-print and return as a `PythonBlock`.
 
@@ -132,7 +135,7 @@ class SourceToSourceTransformation(SourceToSourceTransformationBase):
         assert isinstance(self.input, PythonBlock), self.input
         self._output = self.input
 
-    def pretty_print(self, params: Any = None) -> FileText:
+    def pretty_print(self, params: Optional[FormatParams] = None) -> FileText:
         return self._output.text
 
 
@@ -143,8 +146,7 @@ class SourceToSourceImportBlockTransformation(SourceToSourceTransformationBase):
     def preprocess(self) -> None:
         self.importset = ImportSet(self.input, ignore_shadowed=True)
 
-    def pretty_print(self, params: Any = None) -> str:
-        params = ImportFormatParams(params)
+    def pretty_print(self, params: Optional[FormatParams] = None) -> str:
         return self.importset.pretty_print(params)
 
     def __repr__(self) -> str:
@@ -444,8 +446,9 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
             if isinstance(body_item, _FUNCTION_OR_CLASS_TYPES):
                 self._extract_imports_from_statement(body_item, container)
 
-    def pretty_print(self, params: Any = None) -> FileText:
-        params = ImportFormatParams(params)
+    def pretty_print(self, params: Optional[FormatParams] = None) -> FileText:
+        if params is None:
+            params = FormatParams()
         # Apply deferred local-import removals before rendering the blocks.
         self._apply_local_import_removals(params)
         result = [block.pretty_print(params=params) for block in self.blocks]
@@ -588,7 +591,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
 
         return imp
 
-    def _apply_local_import_removals(self, params: ImportFormatParams) -> None:
+    def _apply_local_import_removals(self, params: FormatParams) -> None:
         """
         Apply the local-import removals recorded by ``remove_import``.
 
@@ -629,7 +632,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
 
     def _rewrite_local_import_statement(
         self, lines: List[str], rel: int, imps: List[Import],
-        params: ImportFormatParams
+        params: FormatParams
     ) -> List[str]:
         """
         Rewrite the import statement starting at ``lines[rel]`` with the
@@ -737,8 +740,8 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
             width = params.max_line_length
             if width is None:
                 width = params.max_line_length_default
-            sub_params = ImportFormatParams(
-                params, max_line_length=max(width - len(indent_str), 1))
+            sub_params = params.replace(
+                max_line_length=max(width - len(indent_str), 1))
             rendered = ImportStatement._from_imports(remaining).pretty_print(
                 sub_params).rstrip("\n")
             new_lines = [
@@ -902,7 +905,7 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
 
 
 def reformat_import_statements(
-    codeblock: Union[PythonBlock, FileText, Filename, str], params: Any = None
+    codeblock: Union[PythonBlock, FileText, Filename, str], params: Optional[FormatParams] = None
 ) -> PythonBlock:
     r"""
     Reformat each top-level block of import statements within a block of code.
@@ -928,11 +931,10 @@ def reformat_import_statements(
     :type codeblock:
       `PythonBlock` or convertible (``str``)
     :type params:
-      `ImportFormatParams`
+      `FormatParams`
     :rtype:
       `PythonBlock`
     """
-    params = ImportFormatParams(params)
     original_tidy_local = SourceToSourceFileImportsTransformation.tidy_local_imports
     try:
         SourceToSourceFileImportsTransformation.tidy_local_imports = False
@@ -967,7 +969,7 @@ def fix_unused_and_missing_imports(
     remove_unused: Union[Literal["AUTOMATIC"], bool] = "AUTOMATIC",
     add_mandatory: bool = True,
     db: Optional[ImportDB] = None,
-    params: Any = None,
+    params: Optional[FormatParams] = None,
     tidy_local_imports: bool = False,
 ) -> PythonBlock:
     r"""
@@ -1023,7 +1025,6 @@ def fix_unused_and_missing_imports(
         pass
     else:
         raise ValueError("Invalid remove_unused=%r" % (remove_unused,))
-    params = ImportFormatParams(params)
     db = ImportDB.interpret_arg(db, target_filename=_codeblock.filename)
     # Do a first pass reformatting the imports to get rid of repeated or
     # shadowed imports, e.g. L1 here:
@@ -1126,7 +1127,7 @@ def fix_unused_and_missing_imports(
 
 
 def remove_broken_imports(
-    codeblock: Union[PythonBlock, FileText, Filename, str], params: Any = None
+    codeblock: Union[PythonBlock, FileText, Filename, str], params: Optional[FormatParams] = None
 ) -> PythonBlock:
     """
     Try to execute each import, and remove the ones that don't work.
@@ -1140,7 +1141,6 @@ def remove_broken_imports(
     """
     if not isinstance(codeblock, PythonBlock):
         codeblock = PythonBlock(codeblock)
-    params = ImportFormatParams(params)
     filename = codeblock.filename
     transformer = SourceToSourceFileImportsTransformation(codeblock)
     for block in transformer.import_blocks:
@@ -1511,7 +1511,7 @@ def _transform_noimport_block(
 def transform_imports(
     codeblock: Union[PythonBlock, FileText, Filename, str],
     transformations: _Transformations,
-    params: Any = None,
+    params: Optional[FormatParams] = None,
     transform_strings: bool = False,
 ) -> PythonBlock:
     """
@@ -1548,7 +1548,6 @@ def transform_imports(
     """
     if not isinstance(codeblock, PythonBlock):
         codeblock = PythonBlock(codeblock)
-    params = ImportFormatParams(params)
     transformer = SourceToSourceFileImportsTransformation(codeblock)
     @memoize
     def transform_import(imp: Import) -> Import:
@@ -1573,7 +1572,7 @@ def transform_imports(
 
 def canonicalize_imports(
     codeblock: Union[PythonBlock, FileText, Filename, str],
-    params: Any = None,
+    params: Optional[FormatParams] = None,
     db: Optional[ImportDB] = None,
 ) -> PythonBlock:
     """
@@ -1587,7 +1586,6 @@ def canonicalize_imports(
     """
     if not isinstance(codeblock, PythonBlock):
         codeblock = PythonBlock(codeblock)
-    params = ImportFormatParams(params)
     db = ImportDB.interpret_arg(db, target_filename=codeblock.filename)
     transformations = db.canonical_imports
     return transform_imports(codeblock, transformations, params=params)

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -7,6 +7,7 @@ from __future__ import annotations, print_function
 
 import ast
 from   collections              import namedtuple
+from   dataclasses              import dataclass
 from   functools                import total_ordering
 
 from   pyflyby._flags           import CompilerFlags
@@ -52,6 +53,7 @@ def read_black_config() -> Dict[str, Any]:
     return config
 
 
+@dataclass(frozen=True)
 class ImportFormatParams(FormatParams):
     align_imports:Union[bool, set, list, tuple, str] = True
     """


### PR DESCRIPTION
Replace the overloaded `__new__` – which constructed from keywords, merged
parameter objects, and returned its argument unchanged when called as
FormatParams(x) – with the generated `__init__` plus two explicit methods:

   - coerce(), for the Params(x) normalization call sites, and
   - replace(), for copy-with-override.  This preserves the concrete class,
     which the open-coded copies had to spell as type(params)(params, **kw);
     one of them hardcoded ImportFormatParams and would have downcast a
     subclass.

max_line_length is now annotated Union[int, float, None]: callers pass
Inf to mean 'never wrap', which the untyped `__new__` had hidden from mypy.
The params arguments that were Any are now Optional[FormatParams], which
is what coerce() has always accepted.