### PR TITLE
Remove dead _ipython_in_multiline

### DIFF
--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -450,23 +450,6 @@ def _install_in_ipython_config_file_40():
         logger.info("[DONE] Removed old file %s (moved to %s)", old_fn, trash_fn)
 
 
-def _ipython_in_multiline(ip):
-    """
-    Return ``False`` if the user has entered only one line of input so far,
-    including the current line, or ``True`` if it is the second or later line.
-
-    :type ip:
-      ``InteractiveShell``
-    :rtype:
-      ``bool``
-    """
-    if hasattr(ip, "input_splitter"):
-        return bool(ip.input_splitter.source)
-    else:
-        # IPython version too old or too new?
-        return False
-
-
 def _get_ipython_app():
     """
     Get an IPython application instance, if we are inside an IPython session.


### PR DESCRIPTION
It has no callers anywhere in the tree, and the ip.input_splitter API it relied on was removed in IPython 9, so it would have returned a constant False regardless.

Last caller was removed in d54f6699762c9436c25aa15aff603e7889ac6cae