### PR TITLE
Unnecessary getattr

### DIFF
--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -409,7 +409,7 @@ class ModuleHandle(object):
         """
         from pyflyby._importclns import ImportStatement, ImportSet
 
-        filename = getattr(self, 'filename', None)
+        filename = self.filename
         if not filename or not filename.exists:
             # Try to load the module to get the filename
             filename = Filename(self.module.__file__)  # type: ignore[arg-type]


### PR DESCRIPTION
Note in particular that a number of assumption that modules do not get
imported are not always true.

In particular anything that access `self.module`; which for example is
triggered to find a module filename::

    ... = Filename(self.module.__file)

Which will import things.

So I'm unsure about the limitatin we have to try to do purely static
analysis of the `__all__` export, as _sometimes_ it might actually
import the modules anyway.
