### PR TITLE
Add --exec-star-imports which allow proper inference of names imported by `import *`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -455,6 +455,37 @@ This style is a maintenance nightmare:
 To fix such code, you can run ``tidy-imports --replace-star-imports`` to
 automatically replace star imports with the specific needed imports.
 
+By default pyflyby works out what ``foopackage`` exports by parsing its source
+rather than running it, so it cannot see an ``__all__`` built at run time -- as
+``numpy`` does.  For those, nothing is found and the star import is left alone.
+Pass ``--exec-star-imports`` to import the module and read its real
+``__all__``::
+
+  tidy-imports --replace-star-imports --exec-star-imports myprogram.py
+
+``--exec-star-imports`` is also useful on its own.  A star import normally
+makes pyflyby give up on the rest of the file, since any undefined name might
+have come from the star.  Knowing what the star supplies, it can fix the rest
+and leave the star in place::
+
+  $ cat myprogram.py
+  from numpy import *
+  print(mkstemp)
+  print(sin)
+
+  $ tidy-imports --exec-star-imports myprogram.py
+  [PYFLYBY] myprogram.py: added 'from tempfile import mkstemp'
+
+``sin`` is left alone because ``numpy`` exports it; ``mkstemp`` is imported
+from where it actually lives.
+
+The flag is off by default because it always executes the module, in pyflyby's
+own process.  Note that the default is not a guarantee that nothing is
+executed: locating ``foo.bar``'s source imports its parent package ``foo``, and
+a module whose source can't be read -- an extension module, say -- is imported
+outright to find out where it lives.  ``--exec-star-imports`` therefore widens
+how much of your code runs, rather than being the only way it can run at all.
+
 Per-Project configuration of tidy-imports
 =========================================
 

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ import os
 import pytest
 import re
 import sys
+from   textwrap                 import dedent
 
 
 _already_ran_setup = False
@@ -91,6 +92,58 @@ def _capture_logger(caplog, name):
 
 
 @pytest.fixture
+def tmp_module(tmp_path):
+    """
+    Factory writing importable modules under a temp dir on ``sys.path``.
+
+    Call as ``tmp_module(name, source)``; returns the name.  Everything is
+    unwound afterwards: sys.modules, ModuleHandle's interned instance (which
+    caches ``exports``/``runtime_exports``), and import_module's memo -- that
+    last one is keyed on the module name alone, so without clearing it a later
+    test reusing a name would silently get this module back.
+    """
+    names = []
+
+    def make(name, source, package=False):
+        if package:
+            (tmp_path / name).mkdir(exist_ok=True)
+            (tmp_path / name / "__init__.py").write_text(dedent(source))
+        else:
+            (tmp_path / (name + ".py")).write_text(dedent(source))
+        names.append(name)
+        return name
+
+    make.path = tmp_path
+    sys.path.insert(0, str(tmp_path))
+    try:
+        yield make
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in names:
+            for mod in [m for m in sys.modules
+                        if m == name or m.startswith(name + ".")]:
+                del sys.modules[mod]
+            ModuleHandle._cls_cache.pop(DottedIdentifier(name), None)
+        import_module.cache_clear()
+
+
+# A module whose __all__ is built at run time, as numpy's is: static parsing
+# can't evaluate it, so only runtime_exports sees alpha and beta.
+DYNAMIC_ALL_SOURCE = """
+    _names = ["alpha", "beta"]
+    for _n in _names:
+        globals()[_n] = _n
+    __all__ = list(_names)
+"""
+
+
+@pytest.fixture
+def dynamic_all_module(tmp_module):
+    """Name of an importable module with a run-time-built ``__all__``."""
+    return tmp_module("pyflyby_test_dynamic_all_49172056", DYNAMIC_ALL_SOURCE)
+
+
+@pytest.fixture
 def pyflyby_log(caplog):
     yield from _capture_logger(caplog, "pyflyby")
 
@@ -152,4 +205,7 @@ fn = re.sub("[.]py[co]$", ".py", pyflyby.__file__)
 expected_fn = os.path.join(PYFLYBY_HOME, "lib/python/pyflyby/__init__.py")
 assert fn == expected_fn, "pyflyby got loaded from %s; expected %s" % (fn, expected_fn)
 
-
+# Imported here rather than at the top of the file: pyflyby must not be
+# imported until sys.path has been fixed up just above.
+from pyflyby._idents import DottedIdentifier  # noqa: E402
+from pyflyby._modules import ModuleHandle, import_module  # noqa: E402

--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -455,6 +455,7 @@ class _MissingImportFinder:
         *,
         find_unused_imports: bool,
         parse_docstrings: bool,
+        exec_star_imports: bool = False,
     ) -> None:
         """
         Construct the AST visitor.
@@ -463,6 +464,8 @@ class _MissingImportFinder:
           `ScopeStack`
         :param scopestack:
           Initial scope stack.
+        :param exec_star_imports:
+          See `_visit_StoreStarImport`.
         """
         # Create a stack of namespaces.  The caller should pass in a list that
         # includes the globals dictionary.  ScopeStack() will make sure this
@@ -483,6 +486,8 @@ class _MissingImportFinder:
         self.unused_imports = []
 
         self.parse_docstrings = parse_docstrings
+
+        self.exec_star_imports = exec_star_imports
 
         # Function bodies that we need to check after defining names in this
         # function scope.
@@ -1111,6 +1116,8 @@ class _MissingImportFinder:
         if is_star:
             logger.debug("Got star import: line %s: 'from %s import *'",
                          self._lineno, modulename)
+            if self._visit_StoreStarImport(modulename):
+                return
         if not node.asname and not is_star:
             # Ensure leading prefixes are treated as defined, so that later
             # references to them are not considered missing.  Don't overwrite
@@ -1140,6 +1147,38 @@ class _MissingImportFinder:
             scope_name = self._scope_name_stack[-1] if self._scope_name_stack else None
             value = _UseChecker(name, imp, self._lineno, scope_name=scope_name)
         self._visit_Store(name, value, in_import=True)
+
+    def _visit_StoreStarImport(self, modulename: Optional[str]) -> bool:
+        """
+        Handle ``from <modulename> import *`` by binding the names the module
+        actually exports, instead of the opaque ``'*'`` that makes
+        `ScopeStack.has_star_import` true and suppresses missing-import
+        detection for the rest of the file.
+
+        Names are bound without a `_UseChecker`, so a star import is never
+        itself reported unused.
+
+        :return:
+          Whether it was resolved; if false, fall back to the ``'*'`` binding.
+        """
+        if not self.exec_star_imports:
+            return False
+        exports = ModuleHandle(modulename).get_exports(allow_exec=True)
+        if not exports:
+            logger.warning(
+                "Found nothing exported by '%s'; treating 'from %s import *' "
+                "as exporting arbitrary names.", modulename, modulename)
+            return False
+        scope = self.scopestack[-1]
+        for imp in exports.imports:
+            name = imp.import_as
+            # Don't rebind: _visit_Store would record the previous binding as
+            # unused, so a conditional star import would delete an earlier
+            # unconditional import that's still needed.
+            if name in scope:
+                continue
+            self._visit_Store(name, None, in_import=True)
+        return True
 
     def _visit_Store(
         self,
@@ -1430,6 +1469,7 @@ def scan_for_import_issues(
     codeblock: Union[PythonBlock, str, FileText, Filename],
     find_unused_imports: bool = True,
     parse_docstrings: bool = False,
+    exec_star_imports: bool = False,
 ) -> Tuple[
     List[Tuple[Optional[int], DottedIdentifier]],
     List[Tuple[Optional[int], Any, Optional[str]]],
@@ -1459,6 +1499,17 @@ def scan_for_import_issues(
         >>> scan_for_import_issues("import foo as bar, baz\\n'{bar}'\\n", parse_docstrings=True)
         ([], [(1, Import('import baz'), None)])
 
+    :param exec_star_imports:
+      Whether to import the module named by ``from foo import *`` to find out
+      which names it supplies.  Without this, a star import suppresses
+      missing-import detection for everything after it::
+
+        >>> scan_for_import_issues("from math import *\\nmkstemp()\\n")
+        ([], [])
+        >>> scan_for_import_issues("from math import *\\nmkstemp()\\n",
+        ...                        exec_star_imports=True)
+        ([(2, DottedIdentifier('mkstemp'))], [])
+
     """
     logger.debug("global scan_for_import_issues()")
     if not isinstance(codeblock, PythonBlock):
@@ -1466,7 +1517,8 @@ def scan_for_import_issues(
     namespaces = ScopeStack([{}])
     finder = _MissingImportFinder(namespaces,
                                   find_unused_imports=find_unused_imports,
-                                  parse_docstrings=parse_docstrings)
+                                  parse_docstrings=parse_docstrings,
+                                  exec_star_imports=exec_star_imports)
     return finder.scan_for_import_issues(codeblock)
 
 

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -971,6 +971,7 @@ def fix_unused_and_missing_imports(
     db: Optional[ImportDB] = None,
     params: Optional[FormatParams] = None,
     tidy_local_imports: bool = False,
+    exec_star_imports: bool = False,
 ) -> PythonBlock:
     r"""
     Check for unused and missing imports, and fix them automatically.
@@ -1006,6 +1007,10 @@ def fix_unused_and_missing_imports(
     :param tidy_local_imports:
       If ``True``, also tidy imports within function and class bodies.
       Defaults to ``False``.
+    :param exec_star_imports:
+      If ``True``, import the module named by a ``from foo import *`` to find
+      out which names it supplies, so the ones it doesn't can still be fixed.
+      The star import itself is left in place; see `replace_star_imports`.
     :rtype:
       `PythonBlock`
     """
@@ -1041,9 +1046,11 @@ def fix_unused_and_missing_imports(
         transformer = SourceToSourceFileImportsTransformation(_codeblock)
     finally:
         SourceToSourceFileImportsTransformation.tidy_local_imports = original_tidy_local
-    missing_imports, unused_imports = scan_for_import_issues(
-        _codeblock, find_unused_imports=remove_unused, parse_docstrings=True
-    )
+    with ImportPathForRelativeImportsCtx(_codeblock):
+        missing_imports, unused_imports = scan_for_import_issues(
+            _codeblock, find_unused_imports=remove_unused,
+            parse_docstrings=True, exec_star_imports=exec_star_imports
+        )
     logger.debug("missing_imports = %r", missing_imports)
     logger.debug("unused_imports = %r", unused_imports)
     if remove_unused and unused_imports:
@@ -1157,7 +1164,9 @@ def remove_broken_imports(
     return transformer.output(params=params)
 
 
-def replace_star_imports(codeblock: PythonBlock, /, params:ImportFormatParams|None = None) -> PythonBlock:
+def replace_star_imports(codeblock: PythonBlock, /,
+                         params:ImportFormatParams|None = None, *,
+                         exec_star_imports: bool=False) -> PythonBlock:
     r"""
     Replace lines such as::
 
@@ -1167,8 +1176,13 @@ def replace_star_imports(codeblock: PythonBlock, /, params:ImportFormatParams|No
 
       from foo.bar import f1, f2, f3
 
-    Note that this requires involves actually importing ``foo.bar``, which may
-    have side effects.  (TODO: rewrite to avoid this?)
+    The exported names are found by parsing ``foo.bar``'s source, which can't
+    see an ``__all__`` built at run time; for such modules (e.g. ``numpy``)
+    nothing is found and the star import is left alone.  Pass
+    ``exec_star_imports=True`` to import ``foo.bar`` instead.
+
+    Note that even without ``exec_star_imports`` this may execute code: see
+    `ModuleHandle.exports`.
 
     The result includes all imports from the ``email`` module.  The result
     excludes shadowed imports.  In this example:
@@ -1188,6 +1202,8 @@ def replace_star_imports(codeblock: PythonBlock, /, params:ImportFormatParams|No
 
     :type codeblock:
       `PythonBlock` or convertible (``str``)
+    :param exec_star_imports:
+      Whether we may import the module to enumerate its exports.
     :rtype:
       `PythonBlock`
     """
@@ -1233,7 +1249,8 @@ def replace_star_imports(codeblock: PythonBlock, /, params:ImportFormatParams|No
                 module = ModuleHandle(imp.split.module_name)
                 try:
                     with ImportPathForRelativeImportsCtx(codeblock):
-                        exports = module.exports
+                        exports = module.get_exports(
+                            allow_exec=exec_star_imports)
                 except Exception as e:
                     logger.warning(
                         "%s: couldn't import '%s' to enumerate exports, "
@@ -1248,8 +1265,10 @@ def replace_star_imports(codeblock: PythonBlock, /, params:ImportFormatParams|No
                     # imports since usually we don't want them.  TODO: do
                     # something better here.
                     logger.warning("%s: found nothing to import from %s, "
-                                   "leaving unchanged: '%s'",
-                                   filename, module, imp)
+                                   "leaving unchanged: '%s'%s",
+                                   filename, module, imp,
+                                   "" if exec_star_imports else
+                                   "; try --exec-star-imports")
                     new_imports.append(imp)
                 else:
                     new_imports.extend(exports)

--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -20,6 +20,7 @@ from   pyflyby._fast_iter_modules \
                                 import _iter_file_finder_modules
 from   pyflyby._file            import FileText, Filename
 from   pyflyby._idents          import DottedIdentifier, is_identifier
+from   pyflyby._importclns      import ImportSet, ImportStatement
 from   pyflyby._log             import logger
 from   pyflyby._util            import (ExcludeImplicitCwdFromPathCtx, cmp,
                                         memoize, prefixes)
@@ -32,7 +33,6 @@ from   typing                   import (Any, Dict, Generator, List, Optional,
                                         TYPE_CHECKING, Tuple, Union)
 
 if TYPE_CHECKING:
-    from   pyflyby._importclns   import ImportSet
     from   pyflyby._parse        import PythonBlock
 
 class ErrorDuringImportError(ImportError):
@@ -397,19 +397,26 @@ class ModuleHandle(object):
     @cached_property
     def exports(self) -> Optional["ImportSet"]:
         """
-        Get symbols exported by this module.
+        Get symbols exported by this module, by parsing its source.
 
         Note that this will not recognize symbols that are dynamically
-        introduced to the module's namespace or __all__ list.
+        introduced to the module's namespace or __all__ list.  Modules that
+        build ``__all__`` at run time (e.g. ``numpy``) yield ``None`` here;
+        see `runtime_exports`.
+
+        This parses rather than runs the module, but that is not a guarantee
+        that no code is executed: `filename` imports the parent package to
+        locate a submodule, and a module whose source can't be read (an
+        extension module, say) is imported outright below to find its
+        ``__file__``.  `runtime_exports` differs in always executing the
+        module itself, not in executing something this never does.
 
         :rtype:
           `ImportSet` or ``None``
         :return:
           Exports, or ``None`` if nothing exported.
         """
-        from pyflyby._importclns import ImportStatement, ImportSet
-
-        filename = self.filename
+        filename = getattr(self, 'filename', None)
         if not filename or not filename.exists:
             # Try to load the module to get the filename
             filename = Filename(self.module.__file__)  # type: ignore[arg-type]
@@ -481,6 +488,70 @@ class ModuleHandle(object):
             return None
         return ImportSet(
             [ ImportStatement.from_parts(str(self.name), members) ])  # type: ignore[arg-type]
+
+    @cached_property
+    def runtime_exports(self) -> Optional["ImportSet"]:
+        """
+        Get symbols exported by this module, by *importing* it.
+
+        Unlike `exports` this sees a dynamically-built ``__all__``, at the cost
+        of executing the module.  Returns exactly what ``from <mod> import *``
+        would bind.
+
+        Note the answer is cached in ``sys.modules`` for the life of the
+        process, so two modules sharing a name can't both be described in one
+        run; the first imported wins.
+
+        :rtype:
+          `ImportSet` or ``None``
+        :return:
+          Exports, or ``None`` if nothing exported.
+        """
+        module = self.module
+        try:
+            names = list(module.__all__)  # type: ignore[attr-defined]
+        except AttributeError:
+            # __dict__, not dir(): a PEP-562 __dir__ would misreport what a
+            # star import binds.
+            names = [n for n in vars(module) if not n.startswith("_")]
+        members = tuple((n, None) for n in names)
+        if not members:
+            return None
+        return ImportSet(
+            [ ImportStatement.from_parts(str(self.name), members) ])  # type: ignore[arg-type]
+
+    def get_exports(self, *, allow_exec: bool = False) -> Optional["ImportSet"]:
+        """
+        Get symbols exported by this module, using `runtime_exports` if
+        ``allow_exec``, else `exports`.
+
+        `runtime_exports` is preferred rather than used only as a fallback,
+        because static analysis is lossy rather than all-or-nothing: it omits
+        names re-exported from unrelated modules, which a star import does
+        bind.  A partial list read as complete would make a caller treat a
+        star-provided name as undefined.  Static analysis remains the fallback
+        for when importing fails.
+
+        :param allow_exec:
+          Whether we may execute the module to enumerate its exports.  Note
+          that ``False`` is not a promise that nothing is executed; see
+          `exports`.
+        :rtype:
+          `ImportSet` or ``None``
+        """
+        if not allow_exec:
+            return self.exports
+        try:
+            return self.runtime_exports
+        except KeyboardInterrupt:
+            raise
+        except BaseException as e:
+            # BaseException, not Exception: module-level sys.exit() is common
+            # in version checks and must not abort the caller's whole run.
+            logger.debug("%s: importing to enumerate exports failed (%s: %s); "
+                         "falling back to static analysis",
+                         self.name, type(e).__name__, e)
+        return self.exports
 
     def __str__(self) -> str:
         return str(self.name)

--- a/lib/python/pyflyby/_replace_star_imports.py
+++ b/lib/python/pyflyby/_replace_star_imports.py
@@ -20,7 +20,7 @@ Only top-level import statements are touched.
 # License: MIT http://opensource.org/licenses/MIT
 
 
-from   pyflyby._cmdline         import parse_args, process_actions
+from   pyflyby._cmdline         import hfmt, parse_args, process_actions
 from   pyflyby._file            import FileText
 from   pyflyby._imports2s       import replace_star_imports
 from   pyflyby._parse           import PythonBlock
@@ -35,9 +35,25 @@ def main():
     if not (__main__.__doc__ or '').strip():
         __main__.__doc__ = __doc__
 
-    options, args = parse_args(modify_action_params=True)
+    def addopts(parser):
+        parser.add_option('--exec-star-imports',
+                          default=False, action='store_true',
+                          help=hfmt('''
+                              Import modules to find out what a star import
+                              supplies, rather than only parsing their source
+                              (which misses a run-time __all__, e.g. numpy's).
+                              This executes the module.'''))
+        parser.add_option('--no-exec-star-imports',
+                          dest='exec_star_imports', action='store_false',
+                          help=hfmt('''
+                              (Default) Only parse module source
+                              statically.'''))
+
+    options, args = parse_args(addopts, modify_action_params=True)
     def modify(x:FileText,/) -> PythonBlock:
-        return replace_star_imports(PythonBlock(x), params=options.params)
+        return replace_star_imports(
+            PythonBlock(x), params=options.params,
+            exec_star_imports=options.exec_star_imports)
     process_actions(args, options.actions, modify)
 
 

--- a/lib/python/pyflyby/_tidy_imports.py
+++ b/lib/python/pyflyby/_tidy_imports.py
@@ -73,6 +73,18 @@ def _addopts(parser):
                         help=hfmt('''
                             (Default) Don't replace 'from foo.bar import
                             *'.'''))
+    parser.add_option('--exec-star-imports',
+                        default=False, action='store_true',
+                        help=hfmt('''
+                            Import modules to find out what a star import
+                            supplies, rather than only parsing their source
+                            (which misses a run-time __all__, e.g. numpy's).
+                            This executes the module.'''))
+    parser.add_option('--no-exec-star-imports',
+                        dest='exec_star_imports',
+                        action='store_false',
+                        help=hfmt('''
+                            (Default) Only parse module source statically.'''))
     parser.add_option('--canonicalize',
                         default=True, action='store_true',
                         help=hfmt('''
@@ -163,13 +175,16 @@ def main() -> None:
                                   params=options.params,
                                   transform_strings=options.transform_strings)
         if options.replace_star_imports:
-            block = replace_star_imports(block, params=options.params)
+            block = replace_star_imports(
+                block, params=options.params,
+                exec_star_imports=options.exec_star_imports)
         block = fix_unused_and_missing_imports(
             block, params=options.params,
             add_missing=options.add_missing,
             remove_unused=options.remove_unused,
             add_mandatory=options.add_mandatory,
             tidy_local_imports=options.tidy_local_imports,
+            exec_star_imports=options.exec_star_imports,
             )
         # TODO: disable sorting until we figure out #287
         # https://github.com/deshaw/pyflyby/issues/287

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -2571,3 +2571,67 @@ def test_unsafe_filename_warning_II(tpp, pyflyby_log):
     with CwdCtx(filepath):
         auto_import("pyflyby", [{}])
     assert pyflyby_log.messages[0] == "import pyflyby"
+
+
+def test_scan_for_import_issues_star_import_exec_1(dynamic_all_module):
+    """Issue #44: names the star module doesn't export are still reported."""
+    code = "from %s import *\nalpha\nmkstemp\n" % dynamic_all_module
+    assert scan_for_import_issues(code, exec_star_imports=True) == (
+        [(3, DottedIdentifier('mkstemp'))], [])
+
+
+def test_scan_for_import_issues_star_import_exec_default_off_1(dynamic_all_module):
+    """Without the flag the star suppresses detection, as before."""
+    code = "from %s import *\nalpha\nmkstemp\n" % dynamic_all_module
+    assert scan_for_import_issues(code) == ([], [])
+
+
+def test_scan_for_import_issues_star_import_exec_not_unused_1(dynamic_all_module):
+    """A star import is never reported unused, even if nothing uses it."""
+    code = "from %s import *\n" % dynamic_all_module
+    assert scan_for_import_issues(code, exec_star_imports=True) == ([], [])
+
+
+def test_scan_for_import_issues_star_import_exec_local_1(dynamic_all_module):
+    code = dedent("""
+        def f():
+            from %s import *
+            return alpha, mkstemp
+    """ % dynamic_all_module)
+    assert scan_for_import_issues(code, exec_star_imports=True) == (
+        [(4, DottedIdentifier('mkstemp'))], [])
+
+
+def test_scan_for_import_issues_star_import_exec_shadowing_1(dynamic_all_module):
+    """Star-bound names neither go missing nor orphan an earlier import."""
+    code = "import os\nfrom %s import *\nalpha\nos\n" % dynamic_all_module
+    assert scan_for_import_issues(code, exec_star_imports=True) == ([], [])
+
+
+def test_scan_for_import_issues_star_import_exec_no_exports_1(tmp_module,
+                                                              pyflyby_log):
+    """A module exporting nothing gives no names to bind; stay conservative."""
+    name = tmp_module("pyflyby_test_noexports_80412663", "__all__ = list([])\n")
+    code = "from %s import *\nmkstemp\n" % name
+    assert scan_for_import_issues(code, exec_star_imports=True) == ([], [])
+    assert any("nothing exported" in m for m in pyflyby_log.messages)
+
+
+def test_scan_for_import_issues_star_import_exec_conditional_1(tmp_module):
+    """
+    A conditional star import must not make an earlier unconditional import
+    look unused; deleting it would leave code raising NameError.
+    """
+    name = tmp_module("pyflyby_test_cond_star_33870915", """
+        def _mk(): return ["join"]
+        __all__ = _mk()
+        def join(*a): pass
+    """)
+    code = dedent("""
+        import sys
+        from os.path import join
+        if sys.version_info >= (3, 99):
+            from %s import *
+        join("a", "b")
+    """ % name)
+    assert scan_for_import_issues(code, exec_star_imports=True) == ([], [])

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -5,6 +5,7 @@
 
 
 
+from   contextlib               import ExitStack
 from   io                       import BytesIO
 import os
 import pexpect
@@ -1294,3 +1295,88 @@ def test_tidy_imports_exclude_arg(tmp_path):
 
     assert foo == txt
     assert foo2 == txt
+
+
+class _StarImportProject:
+    """Temp dir with a dynamic-__all__ module, plus a PYTHONPATH env for it."""
+
+    def __init__(self, stack, modname="dynall", source=None):
+        self.dir = stack.enter_context(tempfile.TemporaryDirectory())
+        self.modname = modname
+        with open(os.path.join(self.dir, modname + ".py"), 'w') as f:
+            f.write(dedent(source if source is not None else '''
+                _names = ["alpha", "beta"]
+                for _n in _names:
+                    globals()[_n] = _n
+                __all__ = list(_names)
+            ''').lstrip())
+        self.env = dict(os.environ, PYTHONPATH=self.dir + os.pathsep +
+                        os.environ.get("PYTHONPATH", ""))
+
+    def write(self, name, content):
+        path = os.path.join(self.dir, name)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def run(self, tool, *args):
+        return pipe(["-m", "pyflyby." + tool, *args], env=self.env)
+
+
+def _code_lines(result):
+    """Split tool output into code lines, dropping [PYFLYBY] log lines."""
+    return [l for l in result.split("\n") if not l.startswith("[PYFLYBY]")]
+
+
+def test_tidy_imports_exec_star_imports_1():
+    """Issue #44: fix other names while leaving the star import alone."""
+    with ExitStack() as stack:
+        p = _StarImportProject(stack)
+        t = p.write("target.py", "from %s import *\nalpha\nmkstemp\n" % p.modname)
+        result = p.run("_tidy_imports", "--exec-star-imports", "--print", t)
+    lines = [l.split() for l in _code_lines(result)]
+    assert "added 'from tempfile import mkstemp'" in result
+    assert ["from", p.modname, "import", "*"] in lines
+    assert ["from", "tempfile", "import", "mkstemp"] in lines
+    assert "alpha'" not in result       # alpha is exported; nothing added for it
+
+
+def test_tidy_imports_exec_star_imports_default_off_1():
+    """Off by default, and --no-exec-star-imports says so explicitly."""
+    with ExitStack() as stack:
+        p = _StarImportProject(stack)
+        t = p.write("target.py", "from %s import *\nalpha\nmkstemp\n" % p.modname)
+        result = p.run("_tidy_imports", "--print", t)
+        explicit_off = p.run("_tidy_imports", "--no-exec-star-imports", "--print", t)
+    assert "added" not in result and "tempfile" not in result
+    assert explicit_off == result
+
+
+def test_tidy_imports_replace_and_exec_star_imports_1():
+    """The README's combination: expand a star with a run-time __all__."""
+    with ExitStack() as stack:
+        p = _StarImportProject(stack)
+        t = p.write("target.py", "from %s import *\nalpha\n" % p.modname)
+        without = p.run("_tidy_imports", "--replace-star-imports", "--print", t)
+        with_flag = p.run("_tidy_imports", "--replace-star-imports",
+                          "--exec-star-imports", "--print", t)
+    assert ["from", p.modname, "import", "*"] in \
+        [l.split() for l in _code_lines(without)]
+    assert ["from", p.modname, "import", "alpha"] in \
+        [l.split() for l in _code_lines(with_flag)]
+    assert "import *" not in "\n".join(_code_lines(with_flag))
+
+
+def test_replace_star_imports_exec_star_imports_1():
+    with ExitStack() as stack:
+        p = _StarImportProject(stack)
+        t = p.write("target.py", "from %s import *\n" % p.modname)
+        without = p.run("_replace_star_imports", "--print", t)
+        explicit_off = p.run("_replace_star_imports", "--no-exec-star-imports",
+                             "--print", t)
+        with_flag = p.run("_replace_star_imports", "--exec-star-imports",
+                          "--print", t)
+    assert "import *" in without and "try --exec-star-imports" in without
+    assert explicit_off == without
+    assert "import alpha, beta" in with_flag
+    assert "import *" not in "\n".join(_code_lines(with_flag))

--- a/tests/test_imports2s.py
+++ b/tests/test_imports2s.py
@@ -1607,3 +1607,88 @@ def test_fix_unused_and_missing_imports_local_semicolon_multibyte_emoji():
     db = ImportDB("")
     output = fix_unused_and_missing_imports(input, db=db)
     assert "import json" in str(output)
+
+
+def test_replace_star_imports_exec_1(dynamic_all_module):
+    """A run-time __all__ needs exec_star_imports to be seen at all."""
+    input = PythonBlock("from %s import *\n" % dynamic_all_module,
+                        filename="/foo/test_replace_star_exec_1.py")
+    assert replace_star_imports(input) == input
+    assert replace_star_imports(input, exec_star_imports=True) == PythonBlock(
+        "from %s import alpha, beta\n" % dynamic_all_module,
+        filename="/foo/test_replace_star_exec_1.py")
+
+
+def test_replace_star_imports_exec_unknown_module_1():
+    input = PythonBlock("from omgnonexistentmodule62294107 import *\n")
+    assert replace_star_imports(input, exec_star_imports=True) == input
+
+
+def test_fix_unused_and_missing_imports_exec_star_1(dynamic_all_module):
+    """
+    Issue #44: a name the star module doesn't export is imported from where it
+    lives, while the star import stays put.
+    """
+    input = PythonBlock("from %s import *\nalpha\nmkstemp\n" % dynamic_all_module,
+                        filename="/foo/test_fix_exec_star_1.py")
+    output = fix_unused_and_missing_imports(input, add_mandatory=False,
+                                            exec_star_imports=True)
+    # Line-wise with whitespace collapsed, to survive alignment changes.
+    assert [" ".join(l.split()) for l in str(output).split("\n") if l.strip()] == [
+        "from %s import *" % dynamic_all_module,
+        "from tempfile import mkstemp",
+        "alpha",
+        "mkstemp",
+    ]
+
+
+@pytest.mark.parametrize("body,exec_star", [
+    # Without the flag the star import suppresses detection, as before.
+    pytest.param("alpha\nmkstemp\n", False, id="flag-off"),
+    # With it, a star import is still never removed as unused.
+    pytest.param("", True, id="star-never-unused"),
+])
+def test_fix_unused_and_missing_imports_exec_star_unchanged_1(dynamic_all_module,
+                                                              body, exec_star):
+    """Cases where the file must come back untouched."""
+    input = PythonBlock("from %s import *\n%s" % (dynamic_all_module, body),
+                        filename="/foo/test_fix_exec_star_unchanged_1.py")
+    assert fix_unused_and_missing_imports(
+        input, add_mandatory=False, exec_star_imports=exec_star) == input
+
+
+def test_fix_unused_and_missing_imports_exec_star_lossy_static_1(tmp_module):
+    """
+    Regression: static analysis omits re-exported names, so trusting it would
+    import a star-provided name from the wrong place, silently changing which
+    function the code calls.
+    """
+    helper = tmp_module("pyflyby_test_i2s_lossy_helper_60934185",
+                        "def sqrt(x): return 'MY-SQRT'\n")
+    lib = tmp_module("pyflyby_test_i2s_lossy_lib_60934185", """
+        from %s import sqrt
+        def alpha(): pass
+    """ % helper)
+    input = PythonBlock("from %s import *\nalpha()\nsqrt(4)\n" % lib,
+                        filename="/foo/test_fix_exec_star_lossy_1.py")
+    assert fix_unused_and_missing_imports(input, add_mandatory=False,
+                                          exec_star_imports=True) == input
+
+
+def test_fix_unused_and_missing_imports_exec_star_conditional_1(tmp_module):
+    """Regression: a conditional star import must not delete a needed import."""
+    name = tmp_module("pyflyby_test_i2s_cond_star_47712096", """
+        def _mk(): return ["join"]
+        __all__ = _mk()
+        def join(*a): pass
+    """)
+    input = PythonBlock(dedent("""
+        import sys
+        from os.path import join
+        if sys.version_info >= (3, 99):
+            from %s import *
+        join("a", "b")
+    """ % name).lstrip(), filename="/foo/test_fix_exec_star_cond_1.py")
+    output = fix_unused_and_missing_imports(input, add_mandatory=False,
+                                            exec_star_imports=True)
+    assert "from os.path import join" in " ".join(str(output).split())

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -4,6 +4,7 @@
 # http://creativecommons.org/publicdomain/zero/1.0/
 
 import hashlib
+import json
 import logging.handlers
 import os
 import pathlib
@@ -11,7 +12,6 @@ from   pkgutil                  import iter_modules
 from   pyflyby._file            import Filename
 from   pyflyby._idents          import DottedIdentifier
 from   pyflyby._log             import logger
-import json
 from   pyflyby._modules         import (ModuleHandle, _fast_iter_modules,
                                         _iter_file_finder_modules,
                                         rebuild_import_cache)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -11,6 +11,7 @@ from   pkgutil                  import iter_modules
 from   pyflyby._file            import Filename
 from   pyflyby._idents          import DottedIdentifier
 from   pyflyby._log             import logger
+import json
 from   pyflyby._modules         import (ModuleHandle, _fast_iter_modules,
                                         _iter_file_finder_modules,
                                         rebuild_import_cache)
@@ -261,3 +262,142 @@ def test_submodules_oserror_fallback():
     names = {str(m.name) for m in submodules}
     # email.mime is a subpackage, exercising _my_iter_modules' package branch.
     assert "email.mime" in names
+
+
+def _exports(importset):
+    """Member names of an `ImportSet`, or None."""
+    if importset is None:
+        return None
+    return {imp.split.member_name for imp in importset.imports}
+
+
+def _star_binds(modname):
+    """Independent oracle: what `from <modname> import *` actually binds."""
+    ns: dict = {}
+    exec("from %s import *" % modname, ns)
+    return {k for k in ns if k != "__builtins__"}
+
+
+def test_exports_static_1():
+    assert _exports(ModuleHandle("json").exports) == set(json.__all__)
+
+
+def test_runtime_exports_dynamic_all_1(dynamic_all_module):
+    """A run-time __all__ is invisible statically but seen by importing."""
+    mh = ModuleHandle(dynamic_all_module)
+    assert mh.exports is None
+    assert _exports(mh.runtime_exports) == {"alpha", "beta"}
+
+
+def test_get_exports_allow_exec_1(dynamic_all_module):
+    mh = ModuleHandle(dynamic_all_module)
+    assert mh.get_exports(allow_exec=False) is None
+    assert _exports(mh.get_exports(allow_exec=True)) == {"alpha", "beta"}
+
+
+def test_get_exports_no_allow_exec_does_not_exec_1(tmp_module):
+    """allow_exec=False must not execute the module itself."""
+    marker = tmp_module.path / "imported.marker"
+    name = tmp_module("pyflyby_test_notimported_20947731", """
+        import pathlib
+        pathlib.Path(%r).write_text("yes")
+        alpha = 1
+    """ % str(marker))
+    assert _exports(ModuleHandle(name).get_exports(allow_exec=False)) == {"alpha"}
+    assert not marker.exists()
+    assert name not in sys.modules
+
+
+def test_get_exports_prefers_runtime_over_lossy_static_1(tmp_module):
+    """
+    Static analysis omits names re-exported from unrelated modules, which a
+    star import does bind, so a non-empty static result must not win.
+    """
+    helper = tmp_module("pyflyby_test_lossy_helper_38104772",
+                        "def sqrt(x): return 'MY-SQRT'\n")
+    lib = tmp_module("pyflyby_test_lossy_lib_38104772", """
+        from %s import sqrt
+        def alpha(): pass
+    """ % helper)
+    mh = ModuleHandle(lib)
+    assert _exports(mh.exports) == {"alpha"}
+    assert _exports(mh.get_exports(allow_exec=True)) == {"alpha", "sqrt"}
+
+
+def test_get_exports_falls_back_to_static_when_import_fails_1(tmp_module):
+    """If the import blows up, fall back to what static analysis found."""
+    name = tmp_module("pyflyby_test_importfail_60355218", """
+        def alpha(): pass
+        raise RuntimeError("boom")
+    """)
+    assert _exports(ModuleHandle(name).get_exports(allow_exec=True)) == {"alpha"}
+
+
+@pytest.mark.parametrize("modname", ["math", "sys", "itertools"])
+def test_get_exports_extension_module_1(modname):
+    """Builtins have no source, so static analysis raises rather than empties."""
+    mh = ModuleHandle(modname)
+    with pytest.raises(Exception):
+        mh.get_exports(allow_exec=False)
+    assert _exports(mh.get_exports(allow_exec=True)) == _star_binds(modname)
+
+
+
+@pytest.mark.parametrize("source,expected,star_legal", [
+    pytest.param("""
+        visible = 1
+        _hidden = 2
+    """, {"visible"}, True, id="no-dunder-all"),
+    # A PEP-562 __dir__ misreports what a star import binds; we use __dict__.
+    pytest.param("""
+        realname = 1
+        def __dir__(): return ["lazyname"]
+        def __getattr__(n):
+            if n == "lazyname": return 2
+            raise AttributeError(n)
+    """, {"realname"}, True, id="dunder-dir"),
+    pytest.param("""
+        alpha = 1
+        __all__ = list([])
+    """, None, False, id="nothing-exported"),
+])
+def test_runtime_exports_1(tmp_module, source, expected, star_legal):
+    name = tmp_module("pyflyby_test_runtime_exports_75330184", source)
+    assert _exports(ModuleHandle(name).runtime_exports) == expected
+    if star_legal:
+        # Cross-check against what Python itself binds.
+        assert _star_binds(name) == expected
+
+
+def test_runtime_exports_submodule_in_all_1(tmp_module):
+    """A submodule named in __all__ is exported even if not imported yet."""
+    pkg = tmp_module("pyflyby_test_pkg_submod_57390142", """
+        def _mk(): return ["submod", "alpha"]
+        __all__ = _mk()
+        alpha = 1
+    """, package=True)
+    (tmp_module.path / pkg / "submod.py").write_text("x = 1\n")
+    assert _exports(ModuleHandle(pkg).runtime_exports) == {"alpha", "submod"}
+
+
+def test_runtime_exports_all_lists_missing_name_1(tmp_module):
+    """__all__ is taken at its word; a real star import would fail the same."""
+    name = tmp_module("pyflyby_test_bad_all_16608259", """
+        real = 1
+        __all__ = list(["real", "nonexistent"])
+    """)
+    assert _exports(ModuleHandle(name).runtime_exports) == {"real", "nonexistent"}
+
+
+def test_runtime_exports_non_string_all_1(tmp_module):
+    """A malformed __all__ raises, so `get_exports` falls back to static."""
+    name = tmp_module("pyflyby_test_badall_type_11947503", """
+        alpha = 1
+        __all__ = list(["alpha", 42])
+    """)
+    mh = ModuleHandle(name)
+    with pytest.raises(Exception):
+        mh.runtime_exports
+    assert "alpha" in _exports(mh.get_exports(allow_exec=True))
+
+


### PR DESCRIPTION
A few notes, 

`ModuleHandle.exports` can already sometime import module to find their filename. 
It is not used currently outside of `--replace-star-import`; but it should be noted that the sometime reference "no-execution" and "no-import" if pyflyby should be checked.

This adds the ability to actually exec the module to get their `__all__`


You can now configure with `--exec-star-imports`, which will now actually imports the modueles when there is an `import *`, and thus properly auto-add or remove missing imports

Closes #44 
