### PR TITLE
Thread exec_star_imports through the auto-importer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -486,6 +486,17 @@ a module whose source can't be read -- an extension module, say -- is imported
 outright to find out where it lives.  ``--exec-star-imports`` therefore widens
 how much of your code runs, rather than being the only way it can run at all.
 
+The same option exists for the auto-importer, where a star import otherwise
+makes it give up on the rest of the code being run.  ``py`` does this by
+default -- the code it is about to run would import the module anyway -- and
+``py --no-exec-star-imports`` turns it off.
+
+In IPython it is off by default; turn it on when enabling the auto-importer,
+e.g. from ``ipython_config.py``::
+
+  import pyflyby
+  pyflyby.enable_auto_importer(exec_star_imports=True)
+
 Per-Project configuration of tidy-imports
 =========================================
 

--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -1525,6 +1525,7 @@ def scan_for_import_issues(
 def _find_missing_imports_in_ast(
     node: ast.AST,
     namespaces: Union[ScopeStack, Dict[str, Any], List[Dict[str, Any]]],
+    exec_star_imports: bool = False,
 ) -> List[DottedIdentifier]:
     """
     Find missing imports in an AST node.
@@ -1538,6 +1539,8 @@ def _find_missing_imports_in_ast(
       ``ast.AST``
     :type namespaces:
       ``dict`` or ``list`` of ``dict``
+    :param exec_star_imports:
+      See `find_missing_imports`.
     :rtype:
       ``list`` of ``DottedIdentifier``
     """
@@ -1547,9 +1550,12 @@ def _find_missing_imports_in_ast(
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("ast=%s", ast.dump(node))
     return _MissingImportFinder(
-                 namespaces,
-                 find_unused_imports=False,
-                 parse_docstrings=False).find_missing_imports(node)
+        namespaces,
+        find_unused_imports=False,
+        parse_docstrings=False,
+        exec_star_imports=exec_star_imports,
+    ).find_missing_imports(node)
+
 
 # TODO: maybe we should replace _find_missing_imports_in_ast with
 # _find_missing_imports_in_code(compile(node)).  The method of parsing opcodes
@@ -1946,6 +1952,8 @@ def _find_earliest_backjump_label(bytecode: bytes) -> int:
 def find_missing_imports(
     arg: Any,
     namespaces: Union[ScopeStack, Dict[str, Any], List[Dict[str, Any]]],
+    *,
+    exec_star_imports: bool = False,
 ) -> List[DottedIdentifier]:
     """
     Find symbols in the given code that require import.
@@ -2019,6 +2027,17 @@ def find_missing_imports(
       >>> [str(m) for m in find_missing_imports("( ( a . b ) . x ) . y + ( c + d ) . x . y", [{}])]
       ['a.b.x.y', 'c', 'd']
 
+    A ``from foo import *`` normally makes us give up on everything after it,
+    since any undefined name might have come from the star.  With
+    ``exec_star_imports``, we import ``foo`` to find out which names it really
+    supplies, and keep reporting the ones it doesn't::
+
+      >>> find_missing_imports("from math import *\\nmkstemp()", [{}])
+      []
+
+      >>> [str(m) for m in find_missing_imports("from math import *\\nmkstemp()", [{}], exec_star_imports=True)]
+      ['mkstemp']
+
     :type arg:
       ``str``, ``ast.AST``, `PythonBlock`, ``callable``, or ``types.CodeType``
     :param arg:
@@ -2029,6 +2048,10 @@ def find_missing_imports(
       ``dict`` or ``list`` of ``dict``
     :param namespaces:
       Stack of namespaces of symbols that exist per scope.
+    :param exec_star_imports:
+      Whether to import the module named by a ``from foo import *`` to find
+      out which names it supplies.  Only meaningful when ``arg`` is source
+      text or an AST; a compiled code object has no star imports left to see.
     :rtype:
       ``list`` of ``DottedIdentifier``
     """
@@ -2049,11 +2072,11 @@ def find_missing_imports(
         # Parse the string into an AST.
         node = ast.parse(arg, type_comments=True) # may raise SyntaxError
         # Get missing imports from AST.
-        return _find_missing_imports_in_ast(node, namespaces)
+        return _find_missing_imports_in_ast(node, namespaces, exec_star_imports)
     elif isinstance(arg, PythonBlock):
-        return _find_missing_imports_in_ast(arg.ast_node, namespaces)
+        return _find_missing_imports_in_ast(arg.ast_node, namespaces, exec_star_imports)
     elif isinstance(arg, ast.AST):
-        return _find_missing_imports_in_ast(arg, namespaces)
+        return _find_missing_imports_in_ast(arg, namespaces, exec_star_imports)
     elif isinstance(arg, types.CodeType):
         return _find_missing_imports_in_code(arg, namespaces)
     elif callable(arg):
@@ -2350,6 +2373,7 @@ def auto_import(
     post_import_hook: Optional[Callable[[Import], Any]] = None,
     *,
     extra_db: Any = None,
+    exec_star_imports: bool = False,
 ) -> Optional[bool]:
     """
     Parse ``arg`` for symbols that need to be imported and automatically import
@@ -2384,6 +2408,11 @@ def auto_import(
       `auto_import_symbol`
     :type post_import_hook:
       ``callable``
+    :param exec_star_imports:
+      Whether to import the module named by a ``from foo import *`` in ``arg``
+      to find out which names it supplies.  Without this, a star import makes
+      us give up on auto-importing anything else in ``arg``.  See
+      `find_missing_imports`.
     :return:
       ``True`` if all symbols are already in the namespace or successfully
       auto-imported; ``False`` if any auto-imports failed, or ``None`` (also
@@ -2396,7 +2425,9 @@ def auto_import(
     else:
         filename = "."
     try:
-        fullnames = find_missing_imports(arg, namespaces)
+        fullnames = find_missing_imports(
+            arg, namespaces, exec_star_imports=exec_star_imports
+        )
     except SyntaxError:
         logger.debug("syntax error parsing %r", arg)
         return False
@@ -2417,11 +2448,17 @@ def auto_import(
     return all(results)
 
 
-def auto_eval(arg: Any, filename: Any = None, mode: Optional[str] = None,
-              flags: Any = None,
-              globals: Optional[Dict[str, Any]] = None,
-              locals: Optional[Dict[str, Any]] = None,
-              db: Any = None) -> Any:
+def auto_eval(
+    arg: Any,
+    filename: Any = None,
+    mode: Optional[str] = None,
+    flags: Any = None,
+    globals: Optional[Dict[str, Any]] = None,
+    locals: Optional[Dict[str, Any]] = None,
+    db: Any = None,
+    *,
+    exec_star_imports: bool = False,
+) -> Any:
     """
     Evaluate/execute the given code, automatically importing as needed.
 
@@ -2475,6 +2512,11 @@ def auto_eval(arg: Any, filename: Any = None, mode: Optional[str] = None,
       `ImportDB`
     :param db:
       Import database to use.
+    :param exec_star_imports:
+      Whether to import the module named by a ``from foo import *`` in ``arg``
+      to find out which names it supplies.  See `find_missing_imports`.  Since
+      ``arg`` is about to be executed anyway, this doesn't run anything that
+      wasn't going to run a moment later.
     :return:
       Result of evaluation (for mode="eval")
     """
@@ -2503,7 +2545,7 @@ def auto_eval(arg: Any, filename: Any = None, mode: Optional[str] = None,
     db = ImportDB.interpret_arg(db, target_filename=filename)
     namespaces = [globals, locals]
     # Import as needed.
-    auto_import(arg, namespaces, db)
+    auto_import(arg, namespaces, db, exec_star_imports=exec_star_imports)
     # Compile from AST to code object.
     if isinstance(arg, types.CodeType):
         code = arg

--- a/lib/python/pyflyby/_comms.py
+++ b/lib/python/pyflyby/_comms.py
@@ -153,9 +153,15 @@ def collect_code_with_imports_on_top(
     )
 
 def run_tidy_imports(code: str) -> str:
+    # exec_star_imports is on here, unlike in tidy-imports: the cells whose
+    # star imports we're resolving have already run in this very kernel.
     return str(
         reformat_import_statements(
-            fix_unused_and_missing_imports(replace_star_imports(PythonBlock(code)))
+            fix_unused_and_missing_imports(
+                replace_star_imports(PythonBlock(code),
+                                     exec_star_imports=True),
+                exec_star_imports=True,
+            )
         )
     )
 

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -851,6 +851,10 @@ class AutoImporter:
     _ast_transformer: Any
     _autoimported_this_cell: Dict[Any, Any]
 
+    # See `enable_auto_importer`.  Assigning on the class sets the default for
+    # the process, which is how 'py --exec-star-imports' turns it on.
+    exec_star_imports: bool = False
+
     def __new__(cls, arg=Ellipsis):
         """
         Get the AutoImporter for the given app, or create and assign one.
@@ -1757,7 +1761,8 @@ class AutoImporter:
             extra_db=self.db,
             autoimported=self._autoimported_this_cell,
             raise_on_error=raise_on_error, on_error=on_error,
-            post_import_hook=post_import_hook)
+            post_import_hook=post_import_hook,
+            exec_star_imports=self.exec_star_imports)
 
     def compile_with_autoimport(self, src, filename, mode, flags=0):
         logger.debug("compile_with_autoimport(%r)", src)
@@ -1778,7 +1783,7 @@ class AutoImporter:
 
 
 
-def enable_auto_importer(if_no_ipython='raise'):
+def enable_auto_importer(if_no_ipython='raise', *, exec_star_imports=None):
     """
     Turn on the auto-importer in the current IPython application.
 
@@ -1787,6 +1792,13 @@ def enable_auto_importer(if_no_ipython='raise'):
       do nothing.
       If we are not inside IPython and if_no_ipython=='raise', then raise
       NoActiveIPythonAppError.
+    :param exec_star_imports:
+      If not ``None``, whether a ``from foo import *`` in the code being run
+      should cause us to import ``foo`` to find out which names it supplies.
+      Without it, a star import makes the auto-importer give up on everything
+      else in that cell.  Off by default; turn it on from e.g.
+      ``ipython_config.py`` with
+      ``pyflyby.enable_auto_importer(exec_star_imports=True)``.
     """
     try:
         app = _get_ipython_app()
@@ -1796,6 +1808,8 @@ def enable_auto_importer(if_no_ipython='raise'):
         else:
             raise
     auto_importer = AutoImporter(app)
+    if exec_star_imports is not None:
+        auto_importer.exec_star_imports = exec_star_imports
     auto_importer.enable()
 
 

--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -118,6 +118,12 @@ Options
       --debug, --d     Run the target code file etc under the debugger.  If a PID is
                        given, then instead attach a debugger to the target PID.
       --verbose        Turn on verbose messages from pyflyby.
+      --no-exec-star-imports
+                       When the code contains 'from foo import *', don't import
+                       foo to find out which names it supplies.  By default we
+                       do, since the code is about to import it anyway; without
+                       it, a star import means we give up on auto-importing
+                       anything else in that code.
 
     Pseudo-actions valid before, after, or without code argument:
 
@@ -306,7 +312,8 @@ from   pyflyby._dbg             import (add_debug_functions_to_builtins,
 from   pyflyby._file            import Filename, UnsafeFilenameError, which
 from   pyflyby._flags           import CompilerFlags
 from   pyflyby._idents          import is_identifier
-from   pyflyby._interactive     import (get_ipython_terminal_app_with_autoimporter,
+from   pyflyby._interactive     import (AutoImporter,
+                                        get_ipython_terminal_app_with_autoimporter,
                                         run_ipython_line_magic,
                                         start_ipython_with_autoimporter)
 from   pyflyby._log             import logger
@@ -1526,6 +1533,10 @@ def _init_virtualenv():
 class _Namespace(object):
     fake_main: ModuleType
 
+    # On by default here, unlike in tidy-imports: the star import is about to
+    # be executed anyway.  See the --no-exec-star-imports global option.
+    exec_star_imports = True
+
     def __init__(self):
         self.fake_main = ModuleType("__main__")
         _init_virtualenv()
@@ -1535,7 +1546,8 @@ class _Namespace(object):
         self.autoimported = {}
 
     def auto_import(self, arg):
-        return auto_import(arg, [self.globals], autoimported=self.autoimported)
+        return auto_import(arg, [self.globals], autoimported=self.autoimported,
+                           exec_star_imports=self.exec_star_imports)
 
     def auto_eval(self, block, mode=None, info=False, auto_import=True,
                   debug=False):
@@ -1550,7 +1562,8 @@ class _Namespace(object):
         if auto_import:
             result = self.auto_import(block)
             if not result:
-                missing = find_missing_imports(block, [self.globals])
+                missing = find_missing_imports(block, [self.globals],
+                                               exec_star_imports=self.exec_star_imports)
                 mstr = ", ".join(repr(str(x)) for x in missing)
                 if result is None:
                     raise ErrorDuringImportError(
@@ -1928,8 +1941,17 @@ class _PyMain(object):
                 del args[0]
                 self.add_deprecated_builtins = True
                 continue
+            if argname in ["exec-star-imports", "exec_star_imports",
+                           "no-exec-star-imports", "no_exec_star_imports"]:
+                del args[0]
+                novalue()
+                self.namespace.exec_star_imports = not argname.startswith("no")
+                continue
             break
         self.args = args
+        # Also applies to any IPython session we start; set on the class
+        # since the app may not exist yet.
+        AutoImporter.exec_star_imports = self.namespace.exec_star_imports
         if postmortem == "auto":
             postmortem = os.isatty(1)
         global _enable_postmortem_debugger

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -2635,3 +2635,46 @@ def test_scan_for_import_issues_star_import_exec_conditional_1(tmp_module):
         join("a", "b")
     """ % name)
     assert scan_for_import_issues(code, exec_star_imports=True) == ([], [])
+
+
+def test_find_missing_imports_star_import_exec_1(dynamic_all_module):
+    """`find_missing_imports` honours exec_star_imports, like the scanner."""
+    code = "from %s import *\nalpha\nmkstemp\n" % dynamic_all_module
+    assert find_missing_imports(code, [{}]) == []
+    assert find_missing_imports(code, [{}], exec_star_imports=True) == \
+        [DottedIdentifier('mkstemp')]
+
+
+def test_find_missing_imports_star_import_exec_ast_1(dynamic_all_module):
+    """Same, when handed an already-parsed AST rather than source text."""
+    node = ast.parse("from %s import *\nalpha\nmkstemp\n" % dynamic_all_module)
+    assert find_missing_imports(node, [{}]) == []
+    assert find_missing_imports(node, [{}], exec_star_imports=True) == \
+        [DottedIdentifier('mkstemp')]
+
+
+def test_auto_import_star_import_exec_1(dynamic_all_module):
+    """With the flag, auto_import imports what the star doesn't supply."""
+    code = "from %s import *\nalpha\nmkstemp\n" % dynamic_all_module
+    namespace = {}
+    assert auto_import(code, [namespace]) is True
+    assert "mkstemp" not in namespace
+    assert auto_import(code, [namespace], exec_star_imports=True) is True
+    from tempfile import mkstemp
+    assert namespace["mkstemp"] is mkstemp
+    # 'alpha' comes from the star import itself, so it's left to the code.
+    assert "alpha" not in namespace
+
+
+def test_auto_eval_star_import_exec_1(dynamic_all_module):
+    code = "from %s import *\nresult = (alpha, mkstemp)\n" % dynamic_all_module
+    namespace = {}
+    auto_eval(code, globals=namespace, exec_star_imports=True)
+    from tempfile import mkstemp
+    assert namespace["result"][1] is mkstemp
+
+
+def test_auto_eval_star_import_exec_default_off_1(dynamic_all_module):
+    code = "from %s import *\nmkstemp\n" % dynamic_all_module
+    with pytest.raises(NameError):
+        auto_eval(code, globals={})

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1380,3 +1380,27 @@ def test_replace_star_imports_exec_star_imports_1():
     assert explicit_off == without
     assert "import alpha, beta" in with_flag
     assert "import *" not in "\n".join(_code_lines(with_flag))
+
+
+def test_py_exec_star_imports_default_on_1():
+    """`py` auto-imports names a star import doesn't supply, by default."""
+    with ExitStack() as stack:
+        p = _StarImportProject(stack)
+        t = p.write("target.py",
+                    "from %s import *\nprint(alpha, mkstemp.__name__)\n"
+                    % p.modname)
+        result = p.run("_py", t)
+        explicit_on = p.run("_py", "--exec-star-imports", t)
+    assert "[PYFLYBY] from tempfile import mkstemp" in result
+    assert "alpha mkstemp" in result
+    assert explicit_on == result
+
+
+def test_py_no_exec_star_imports_1():
+    """--no-exec-star-imports goes back to giving up after the star import."""
+    with ExitStack() as stack:
+        p = _StarImportProject(stack)
+        t = p.write("target.py", "from %s import *\nprint(mkstemp)\n" % p.modname)
+        result = p.run("_py", "--no-exec-star-imports", t)
+    assert "NameError: name 'mkstemp' is not defined" in result
+    assert "[PYFLYBY]" not in result

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -3937,3 +3937,41 @@ def test_breakpoint_IOStream_broken():
         ''',
             frontend='prompt_toolkit',
         )
+
+
+@retry
+def test_autoimport_exec_star_imports_1(tmp):
+    # exec_star_imports lets the auto-importer keep working on the rest of a
+    # cell that contains a star import.
+    writetext(tmp.dir/"m30742118_dynall.py", """
+        _names = ["alpha30742118"]
+        for _n in _names:
+            globals()[_n] = _n
+        __all__ = list(_names)
+    """)
+    ipython("""
+        In [1]: import pyflyby; pyflyby.enable_auto_importer(exec_star_imports=True)
+        In [2]: from m30742118_dynall import *; (alpha30742118, b64decode(b'aGk='))
+        [PYFLYBY] from base64 import b64decode
+        Out[2]: ('alpha30742118', b'hi')
+    """, PYTHONPATH=tmp.dir)
+
+
+@retry
+def test_autoimport_exec_star_imports_default_off_1(tmp):
+    # Without it, the star import suppresses auto-importing for the rest of
+    # the cell, as before.
+    writetext(tmp.dir/"m30742119_dynall.py", """
+        _names = ["alpha30742119"]
+        for _n in _names:
+            globals()[_n] = _n
+        __all__ = list(_names)
+    """)
+    ipython("""
+        In [1]: import pyflyby; pyflyby.enable_auto_importer()
+        In [2]: from m30742119_dynall import *; (alpha30742119, b64decode(b'aGk='))
+        ---------------------------------------------------------------------------
+        NameError                                 Traceback (most recent call last)
+        ... in ...
+        NameError: name 'b64decode' is not defined
+    """, PYTHONPATH=tmp.dir)


### PR DESCRIPTION
--exec-star-imports was only reachable from tidy-imports and replace-star-imports.  find_missing_imports() built its _MissingImportFinder without the flag, so auto_import()/auto_eval() -- the path used by py, the IPython auto-importer, and the JupyterLab tidy-imports button -- always fell back to the opaque '*' binding and gave up on everything after a star import.

Thread the keyword through _find_missing_imports_in_ast, find_missing_imports, auto_import and auto_eval, defaulting to False as elsewhere.  It is ignored for code objects, which have no star imports left to see.

Turn it on by default in py: the code py is about to run would import the module a moment later anyway, so this executes nothing new. --no-exec-star-imports opts out.  It carries into the IPython session started by py -i.

Elsewhere it stays opt-in.  In IPython, enable it with pyflyby.enable_auto_importer(exec_star_imports=True).  The JupyterLab tidy-imports comm uses it unconditionally, since the cells whose star imports it resolves have already run in that same kernel.

Closes #122.