### PR TITLE
Factor out tidy-imports pragma parsing

### DIFF
--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -983,8 +983,8 @@ def fix_unused_and_missing_imports(
 
     Individual imports can be excluded from removal by adding
     ``# tidy-imports: ignore-import`` as a trailing comment.
-    This is whitespace sentitive between and must be a single space after the
-    `#`, and after the `:`
+    This is whitespace sensitive: there must be exactly one space after the
+    ``#``, and one after the ``:``.
 
     In the example below, ``m1`` and ``m3`` are unused, so are automatically
     removed.  ``np`` was undefined, so an ``import numpy as np`` was

--- a/lib/python/pyflyby/_util.py
+++ b/lib/python/pyflyby/_util.py
@@ -26,6 +26,63 @@ __all__ = ["cached_attribute", "memoize"]
 _T = TypeVar("_T")
 
 
+# Pragmas all have the shape ``# tidy-imports: <directive>[ arg, arg, ...]``,
+# with exactly one space after the ``#`` and after the ``:``.
+_PRAGMA_MARKER = "# tidy-imports: "
+
+
+def _pragma_args(line: str, directive: str) -> "Optional[List[str]]":
+    """Return the arguments passed to ``directive`` on ``line``.
+
+    Arguments are comma-separated; surrounding whitespace is stripped.
+    Returns ``None`` if ``line`` carries no such pragma, and ``[]`` if the
+    pragma is bare.  The pragma is spelled with exactly one space after the
+    ``#`` and after the ``:``.
+
+      >>> _pragma_args("x  # tidy-imports: some-directive foo, bar", "some-directive")
+      ['foo', 'bar']
+      >>> _pragma_args("import os  # tidy-imports: ignore-import", "ignore-import")
+      []
+      >>> _pragma_args("import os  #tidy-imports:ignore-import", "ignore-import")
+      >>> _pragma_args("import os  # tidy-imports: ignore-import", "some-directive")
+    """
+    result: Optional[List[str]] = None
+    pos = 0
+    while True:
+        idx = line.find(_PRAGMA_MARKER, pos)
+        if idx < 0:
+            return result
+        pos = idx + len(_PRAGMA_MARKER)
+        # Anything from a subsequent '#' on belongs to another comment.
+        found, _, args = line[pos:].split("#", 1)[0].partition(" ")
+        if found != directive:
+            continue
+        if result is None:
+            result = []
+        result.extend(a for a in (arg.strip() for arg in args.split(",")) if a)
+
+
+def _lines_have_pragma(
+    lines: "Sequence[str] | None",
+    directive: str,
+    lineno: "int | None",
+    end_lineno: "int | None" = None,
+) -> bool:
+    """Check whether any line in ``[lineno, end_lineno]`` carries ``directive``.
+
+    When ``end_lineno`` is omitted only ``lineno`` is checked.
+    """
+    if lines is None or lineno is None:
+        return False
+    if end_lineno is None:
+        end_lineno = lineno
+    for ln in range(lineno, end_lineno + 1):
+        idx = ln - 1
+        if 0 <= idx < len(lines) and _pragma_args(lines[idx], directive) is not None:
+            return True
+    return False
+
+
 def _has_ignore_pragma(
     lines: "list[str] | None",
     lineno: "int | None",
@@ -39,15 +96,7 @@ def _has_ignore_pragma(
     that actually contains the imported name).  When ``end_lineno`` is omitted
     only ``lineno`` is checked.
     """
-    if lines is None or lineno is None:
-        return False
-    if end_lineno is None:
-        end_lineno = lineno
-    for ln in range(lineno, end_lineno + 1):
-        idx = ln - 1
-        if 0 <= idx < len(lines) and "# tidy-imports: ignore-import" in lines[idx]:
-            return True
-    return False
+    return _lines_have_pragma(lines, "ignore-import", lineno, end_lineno)
 
 
 def stable_unique(items: Iterable[_T]) -> List[_T]:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,8 +5,10 @@
 
 
 
-from   pyflyby._util            import (longest_common_prefix, partition,
-                                        prefixes, stable_unique)
+import pytest
+
+from   pyflyby._util            import (_pragma_args, longest_common_prefix,
+                                        partition, prefixes, stable_unique)
 
 
 def test_stable_unique_1():
@@ -25,3 +27,20 @@ def test_partition_1():
     result = partition('12321233221', lambda c: int(c) % 2 == 0)
     expected = (['2', '2', '2', '2', '2'], ['1', '3', '1', '3', '3', '1'])
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("line", "directive", "expected"),
+    [
+        ("import os  # tidy-imports: ignore-import", "ignore-import", []),
+        # Spacing is strict: exactly one space after the '#' and after the ':'.
+        ("import os  #tidy-imports:ignore-import", "ignore-import", None),
+        ("import os  #  tidy-imports:  ignore-import", "ignore-import", None),
+        ("import os  # tidy-imports: ignore-import x , y", "ignore-import", ["x", "y"]),
+        # Directives match in full, not as a prefix.
+        ("import os  # tidy-imports: ignore-imports", "ignore-import", None),
+        ("x = 1  # ordinary comment", "ignore-import", None),
+    ],
+)
+def test_pragma_args(line, directive, expected):
+    assert _pragma_args(line, directive) == expected


### PR DESCRIPTION
All source pragmas share the shape '# tidy-imports: <directive> [args]'. Parse them in one place (_pragma_args / _lines_have_pragma) so new directives only have to name themselves, instead of substring-matching each pragma text.  Spacing stays strict -- exactly one space after the '#' and after the ':' -- and a directive now matches in full rather than as a substring.


Mostly to ruse for another pragma feature 