### PR TITLE
Give pragma directives bracketed arguments and fix #73

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,35 @@ This works for both top-level and local imports, and for ``from`` style imports:
        import pdb  # tidy-imports: ignore-import
        ...
 
+Ignoring undefined names
+------------------------
+
+Some files use names that are injected by the runtime rather than imported,
+such as ``c`` and ``get_config`` in IPython/Jupyter configuration files.
+``tidy-imports`` reports those as ``undefined name 'c' and no known import for
+it``.  To silence that, list the names in brackets after a
+``# tidy-imports: ignore-undefined`` pragma; they are then ignored anywhere in
+the file:
+
+.. code:: python
+
+   # tidy-imports: ignore-undefined[c,get_config]
+
+   c.NotebookApp.port = 8888
+
+Alternatively, put a bare pragma as a trailing comment on the line where the
+name is used.  The names are then inferred from that line and treated as
+defined for the whole file, so the pragma only needs to be written once, on
+the first use:
+
+.. code:: python
+
+   c.NotebookApp.port = 8888  # tidy-imports: ignore-undefined
+   c.NotebookApp.ip = "*"     # no pragma needed here
+
+An ignored name is neither warned about nor auto-imported, even if a known
+import exists for it.
+
 Quick start: import libraries
 =============================
 

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -20,6 +20,7 @@ from   pyflyby._log             import logger
 from   pyflyby._modules         import ModuleHandle
 from   pyflyby._parse           import PythonBlock, PythonStatement
 from   pyflyby._util            import (ImportPathCtx, Inf, _has_ignore_pragma,
+                                        _parse_ignore_undefined_pragmas,
                                         memoize)
 
 import re
@@ -988,6 +989,19 @@ def fix_unused_and_missing_imports(
     separated by commas, and a directive that takes arguments is written
     ``directive[arg1,arg2]``.
 
+    Undefined names for which no import is known can be excluded from the
+    "undefined name ... and no known import for it" warning with a
+    ``# tidy-imports: ignore-undefined`` pragma.  Listing the names in
+    brackets ignores them anywhere in the file::
+
+        # tidy-imports: ignore-undefined[c,get_config]
+
+    while a bare pragma infers them from its own line, so it only needs to be
+    written once, on the first use::
+
+        c.NotebookApp.port = 8888  # tidy-imports: ignore-undefined
+        c.NotebookApp.ip = "*"     # no pragma needed here
+
     In the example below, ``m1`` and ``m3`` are unused, so are automatically
     removed.  ``np`` was undefined, so an ``import numpy as np`` was
     automatically added.
@@ -1099,8 +1113,19 @@ def fix_unused_and_missing_imports(
         # block with the longest common prefix.  Tie-break by preferring later
         # blocks.
         added_imports = set()
+        ignored_names, ignored_linenos = _parse_ignore_undefined_pragmas(
+            str(_codeblock.text).split("\n"))
+        # A bare pragma infers its names from the undefined ones on its line.
+        ignored_names |= set(
+            ident.parts[0]
+            for lineno, ident in missing_imports
+            if lineno in ignored_linenos)
         for lineno, ident in missing_imports:
             import_as = ident.parts[0]
+            if import_as in ignored_names or str(ident) in ignored_names:
+                logger.debug("%s:%s: ignoring undefined name %r",
+                             filename, lineno, import_as)
+                continue
             try:
                 imports = known[import_as]
             except KeyError:

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -984,7 +984,9 @@ def fix_unused_and_missing_imports(
     Individual imports can be excluded from removal by adding
     ``# tidy-imports: ignore-import`` as a trailing comment.
     This is whitespace sensitive: there must be exactly one space after the
-    ``#``, and one after the ``:``.
+    ``#``, and one after the ``:``.  Several directives may share one pragma,
+    separated by commas, and a directive that takes arguments is written
+    ``directive[arg1,arg2]``.
 
     In the example below, ``m1`` and ``m3`` are unused, so are automatically
     removed.  ``np`` was undefined, so an ``import numpy as np`` was

--- a/lib/python/pyflyby/_util.py
+++ b/lib/python/pyflyby/_util.py
@@ -125,6 +125,28 @@ def _has_ignore_pragma(
     return _lines_have_pragma(lines, "ignore-import", lineno, end_lineno)
 
 
+def _parse_ignore_undefined_pragmas(
+    lines: "Sequence[str] | None",
+) -> "Tuple[set, set]":
+    """Find ``# tidy-imports: ignore-undefined`` pragmas in ``lines``.
+
+    :return:
+      ``(names, linenos)``: names listed explicitly, and the 1-indexed line
+      numbers of bare pragmas, whose names the caller infers.
+    """
+    names: set = set()
+    linenos: set = set()
+    for lineno, line in enumerate(lines or (), 1):
+        args = _pragma_args(line, "ignore-undefined")
+        if args is None:
+            continue
+        if args:
+            names.update(args)
+        else:
+            linenos.add(lineno)
+    return names, linenos
+
+
 def stable_unique(items: Iterable[_T]) -> List[_T]:
     """
     Return a copy of ``items`` without duplicates.  The order of other items is

--- a/lib/python/pyflyby/_util.py
+++ b/lib/python/pyflyby/_util.py
@@ -26,25 +26,48 @@ __all__ = ["cached_attribute", "memoize"]
 _T = TypeVar("_T")
 
 
-# Pragmas all have the shape ``# tidy-imports: <directive>[ arg, arg, ...]``,
-# with exactly one space after the ``#`` and after the ``:``.
+# A pragma comment is ``# tidy-imports: `` -- exactly one space after the ``#``
+# and after the ``:`` -- followed by a comma-separated list of directives,
+# each of which may carry bracketed arguments, e.g.::
+#
+#     # tidy-imports: ignore-import
+#     # tidy-imports: ignore-undefined[c,get_config]
+#     # tidy-imports: ignore-import,ignore-undefined[c,d]
 _PRAGMA_MARKER = "# tidy-imports: "
+
+
+def _split_toplevel_commas(text: str) -> "Iterator[str]":
+    """Split ``text`` on commas that are not inside ``[]``.
+
+      >>> list(_split_toplevel_commas("a[1,2],b"))
+      ['a[1,2]', 'b']
+    """
+    depth = 0
+    start = 0
+    for i, c in enumerate(text):
+        if c == "[":
+            depth += 1
+        elif c == "]":
+            depth = max(0, depth - 1)
+        elif c == "," and depth == 0:
+            yield text[start:i]
+            start = i + 1
+    yield text[start:]
 
 
 def _pragma_args(line: str, directive: str) -> "Optional[List[str]]":
     """Return the arguments passed to ``directive`` on ``line``.
 
-    Arguments are comma-separated; surrounding whitespace is stripped.
-    Returns ``None`` if ``line`` carries no such pragma, and ``[]`` if the
-    pragma is bare.  The pragma is spelled with exactly one space after the
-    ``#`` and after the ``:``.
+    Arguments are given in brackets and separated by commas; whitespace around
+    directives and arguments is stripped.  Returns ``None`` if ``line`` carries
+    no such directive, and ``[]`` if it is given without arguments.
 
-      >>> _pragma_args("x  # tidy-imports: some-directive foo, bar", "some-directive")
+      >>> _pragma_args("x  # tidy-imports: some-directive[foo, bar]", "some-directive")
       ['foo', 'bar']
-      >>> _pragma_args("import os  # tidy-imports: ignore-import", "ignore-import")
+      >>> _pragma_args("x  # tidy-imports: ignore-import, other[a]", "ignore-import")
       []
       >>> _pragma_args("import os  #tidy-imports:ignore-import", "ignore-import")
-      >>> _pragma_args("import os  # tidy-imports: ignore-import", "some-directive")
+      >>> _pragma_args("import os  # tidy-imports: ignore-import", "other")
     """
     result: Optional[List[str]] = None
     pos = 0
@@ -54,12 +77,15 @@ def _pragma_args(line: str, directive: str) -> "Optional[List[str]]":
             return result
         pos = idx + len(_PRAGMA_MARKER)
         # Anything from a subsequent '#' on belongs to another comment.
-        found, _, args = line[pos:].split("#", 1)[0].partition(" ")
-        if found != directive:
-            continue
-        if result is None:
-            result = []
-        result.extend(a for a in (arg.strip() for arg in args.split(",")) if a)
+        for chunk in _split_toplevel_commas(line[pos:].split("#", 1)[0]):
+            name, bracket, rest = chunk.partition("[")
+            if name.strip() != directive:
+                continue
+            if result is None:
+                result = []
+            if bracket:
+                args = rest.rpartition("]")[0] if "]" in rest else rest
+                result.extend(a for a in (arg.strip() for arg in args.split(",")) if a)
 
 
 def _lines_have_pragma(

--- a/tests/test_imports2s_bis.py
+++ b/tests/test_imports2s_bis.py
@@ -544,3 +544,55 @@ def test_ignore_import_pragma(
     for s in expect_absent:
         with subtests.test(msg="absent", i=s):
             assert s not in result, f"expected {s!r} to be absent"
+
+
+@pytest.mark.parametrize(
+    ("code", "expect_warned", "expect_unwarned"),
+    [
+        pytest.param(
+            """\
+# tidy-imports: ignore-undefined[c,get_config]
+c.NotebookApp.port = 8888
+get_config()
+other_thing()
+""",
+            ["other_thing"],
+            ["c", "get_config"],
+            id="names_listed_explicitly",
+        ),
+        pytest.param(
+            """\
+print(c)
+c.port = foo(bar)  # tidy-imports: ignore-undefined
+print(c, foo)
+d.foo = 1
+""",
+            ["d"],
+            ["c", "foo", "bar"],
+            id="bare_pragma_infers_names_for_whole_file",
+        ),
+    ],
+)
+def test_ignore_undefined_pragma(
+    subtests, capsys, code, expect_warned, expect_unwarned
+):
+    fix_unused_and_missing_imports(PythonBlock(dedent(code).lstrip()), db=ImportDB(""))
+    out, err = capsys.readouterr()
+    assert not err
+    for name in expect_warned:
+        with subtests.test(msg="warned", i=name):
+            assert "undefined name %r" % name in out
+    for name in expect_unwarned:
+        with subtests.test(msg="unwarned", i=name):
+            assert "undefined name %r" % name not in out
+
+
+def test_ignore_undefined_pragma_suppresses_add(capsys):
+    """An ignored name is not auto-imported either."""
+    input_block = PythonBlock("# tidy-imports: ignore-undefined[np]\nnp.zeros(3)\n")
+    db = ImportDB("import numpy as np")
+    output = fix_unused_and_missing_imports(input_block, db=db, add_mandatory=False)
+    assert "import numpy" not in str(output)
+    out, err = capsys.readouterr()
+    assert not err
+    assert "undefined name" not in out

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,8 @@
 
 import pytest
 
-from   pyflyby._util            import (_pragma_args, longest_common_prefix,
+from   pyflyby._util            import (_parse_ignore_undefined_pragmas,
+                                        _pragma_args, longest_common_prefix,
                                         partition, prefixes, stable_unique)
 
 
@@ -48,3 +49,13 @@ def test_partition_1():
 )
 def test_pragma_args(line, directive, expected):
     assert _pragma_args(line, directive) == expected
+
+
+def test_parse_ignore_undefined_pragmas():
+    lines = [
+        "# tidy-imports: ignore-undefined[c, get_config]",
+        "d.foo  # tidy-imports: ignore-undefined",
+        "e.foo",
+    ]
+    assert _parse_ignore_undefined_pragmas(lines) == ({"c", "get_config"}, {2})
+    assert _parse_ignore_undefined_pragmas([]) == (set(), set())

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -36,7 +36,11 @@ def test_partition_1():
         # Spacing is strict: exactly one space after the '#' and after the ':'.
         ("import os  #tidy-imports:ignore-import", "ignore-import", None),
         ("import os  #  tidy-imports:  ignore-import", "ignore-import", None),
-        ("import os  # tidy-imports: ignore-import x , y", "ignore-import", ["x", "y"]),
+        # Arguments go in brackets; several directives can share one pragma.
+        ("x  # tidy-imports: some[ a , b ]", "some", ["a", "b"]),
+        ("x  # tidy-imports: one[a],two[b]", "two", ["b"]),
+        ("x  # tidy-imports: one[a],two", "two", []),
+        ("x  # tidy-imports: one[a],two[b]", "three", None),
         # Directives match in full, not as a prefix.
         ("import os  # tidy-imports: ignore-imports", "ignore-import", None),
         ("x = 1  # ordinary comment", "ignore-import", None),


### PR DESCRIPTION
Arguments are now written 'directive[arg1,arg2]', and one pragma can
carry several comma-separated directives:

    # tidy-imports: ignore-import,ignore-undefined[c,d]

This keeps directive names unambiguous once directives that take
arguments exist.


And fix #73 (Ability to ignore undefined name with no known import)