### PR TITLE
Fix _escape_for_gdb() to mark backslash as unsave on have only 3 char…

### DIFF
--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -991,18 +991,19 @@ def get_executable(pid):
 
 _gdb_safe_chars = (
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    r"0123456789,./-_=+:;'[]{}\|`~!@#%^&*()<>? ")
+    r"0123456789,./-_=+:;'[]{}|`~!@#%^&*()<>? ")
 
 def _escape_for_gdb(string):
     """
     Escape a string to make it safe for passing to gdb.
     """
     result = []
-    for char in string:
+    for byte in string.encode("utf-8"):
+        char = chr(byte)
         if char in _gdb_safe_chars:
             result.append(char)
         else:
-            result.append(r"\0{0:o}".format(ord(char)))
+            result.append(r"\{0:03o}".format(byte))
     return ''.join(result)
 
 

--- a/tests/test_dbg.py
+++ b/tests/test_dbg.py
@@ -794,6 +794,15 @@ def test_escape_for_gdb_unsafe_chars():
     assert result.startswith("a")
 
 
+def test_escape_for_gdb_escapes_backslash():
+    assert dbg._escape_for_gdb("\\") == r"\134"
+    assert "\\" not in dbg._escape_for_gdb("a\\nb").replace(r"\134", "")
+
+
+def test_escape_for_gdb_octal_is_three_digits():
+    assert dbg._escape_for_gdb("\N{EURO SIGN}") == r"\342\202\254"
+
+
 # ---------------------------------------------------------------------------
 # _dev_null
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…s octals

`\` is not safe, as `s = 'A\\nB'` should be string with a backslash and n, but arrive as AB separated by new lines. So encode backslash

Octal should also alway be 3 chars wide, so update the formatting.

Mostly step toward #131, because I want it to be able to take multiline code blocks instead of list of statements.