### PR TITLE
Fix #131 remote debug coredump when remote debugging is interrupted

### DIFF
--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -12,6 +12,7 @@ import pwd
 import signal
 import sys
 import time
+import tty
 from   types                    import CodeType, FrameType, TracebackType
 
 from   collections.abc          import Callable
@@ -1022,7 +1023,12 @@ def _dev_null():
     return _memoized_dev_null
 
 
-def inject(pid, statements, wait=True, show_gdb_output=False):
+def inject(
+    pid: int,
+    statements: list[str] | str,
+    wait: bool = True,
+    show_gdb_output: bool = False,
+):
     """
     Execute ``statements`` in a running Python process.
 
@@ -1083,9 +1089,15 @@ def inject(pid, statements, wait=True, show_gdb_output=False):
     # easier to parse than the normal human-oriented output (it is also worth
     # noting that at the moment we are never parsig the output, but it's still
     # a good practice to use --interpreter=mi).
-    command = (
-        ['gdb', '-n', str(python_path), '-p', str(pid), '-batch', '--interpreter=mi']
-        + [ '-eval-command=call %s' % (c,) for c in gdb_commands ])
+    command = [
+        "gdb",
+        "-n",
+        str(python_path),
+        "-p",
+        str(pid),
+        "-batch",
+        "--interpreter=mi",
+    ] + ["-eval-command=call %s" % (c,) for c in gdb_commands]
 
     output = subprocess.PIPE if show_gdb_output else _dev_null()
 
@@ -1102,7 +1114,6 @@ def inject(pid, statements, wait=True, show_gdb_output=False):
     else:
         return process.pid
 
-import tty
 
 
 # Copy of tty.setraw that does not set ISIG,

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -18,6 +18,7 @@ from   types                    import CodeType, FrameType, TracebackType
 from   collections.abc          import Callable
 
 from   pyflyby._file            import Filename
+import textwrap
 
 
 """
@@ -1250,18 +1251,33 @@ def attach_debugger(pid):
     #
     # As a concrete example, `typing` module is a package as well a built-in
     # module from Python version >= 3.5
-    statements = [
-        "loader = __import__('importlib').machinery.PathFinder.find_module("
-        "fullname='pyflyby', path=['{pyflyby_dir}'])".format(
-            pyflyby_dir=pyflyby_lib_path),
-        "pyflyby = loader.load_module('pyflyby')"
-    ]
-    statements.append(
-        ("pyflyby.debugger(tty=%r, on_continue=%s)"
-         % (terminal.ttyname, on_continue))
+    block = (
+        textwrap.dedent(
+            """
+        import sys
+        try:
+            pyflyby = sys.modules.get('pyflyby')
+            if pyflyby is None:
+                import importlib.machinery
+                import importlib.util
+                _spec = importlib.machinery.PathFinder.find_spec(
+                    'pyflyby', [__PYFLYBY_DIR__])
+                pyflyby = importlib.util.module_from_spec(_spec)
+                sys.modules['pyflyby'] = pyflyby
+                _spec.loader.exec_module(pyflyby)
+            pyflyby.debugger(tty=__PYFLYBY_TTY__,
+                             on_continue=__PYFLYBY_ON_CONTINUE__)
+        except Exception:
+            import traceback
+            traceback.print_exc()
+        """
         )
+        .replace("__PYFLYBY_DIR__", repr(pyflyby_lib_path))
+        .replace("__PYFLYBY_TTY__", repr(terminal.ttyname))
+        .replace("__PYFLYBY_ON_CONTINUE__", on_continue)
+    )
 
-    gdb_pid = inject(pid, statements=";".join(statements), wait=False)
+    gdb_pid = inject(pid, statements=block, wait=False)
     # Fork a watchdog process to make sure we exit if the target process or
     # gdb process exits, and make sure the gdb process exits if we exit.
     parent_pid = os.getpid()

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -1072,11 +1072,29 @@ def inject(
     # https://github.com/lmacken/pyrasite/blob/master/pyrasite/inject.py
     # TODO: add error checking
     # TODO: consider using lldb, especially on Darwin.
-    gdb_commands = (
-        [ 'PyGILState_Ensure()' ]
-        + [ 'PyRun_SimpleString("%s")' % (_escape_for_gdb(statement),)
-            for statement in statements ]
-        + [ 'PyGILState_Release($1)' ])
+    #
+    # Unlike pyrasite, we put everything in a single gdb expression.  Running
+    # the handshake as three separate -eval-commands means that when gdb
+    # abandons the PyRun_SimpleString() call -- which happens whenever a
+    # signal reaches the target while the injected debugger session is still
+    # open -- gdb goes on to run the *next* command anyway, and
+    # PyGILState_Release() then executes against a thread state that is no
+    # longer current, which CPython answers by aborting the process.  That is
+    # issue #131.  Joined with "," (gdb's expression separator) there is no
+    # next command: if the payload is abandoned, the paired release is simply
+    # never evaluated.  That leaks the GIL state we acquired, which is the
+    # deliberate trade-off here -- it only ever happens to a process someone
+    # is already attaching a debugger to.
+    gdb_expression = "(%s)" % (
+        ", ".join(
+            ["$gilstate = PyGILState_Ensure()"]
+            + [
+                'PyRun_SimpleString("%s")' % (_escape_for_gdb(statement),)
+                for statement in statements
+            ]
+            + ["PyGILState_Release($gilstate)", "0"]
+        ),
+    )
     python_path = get_executable(pid)
     if "python" not in python_path.base:
         raise ValueError(
@@ -1097,7 +1115,8 @@ def inject(
         str(pid),
         "-batch",
         "--interpreter=mi",
-    ] + ["-eval-command=call %s" % (c,) for c in gdb_commands]
+        f"-eval-command=call {gdb_expression}",
+    ]
 
     output = subprocess.PIPE if show_gdb_output else _dev_null()
 


### PR DESCRIPTION
This contains mostly 2 refactors in addition to the bug fix:

   - Inject a real code block instead of list of statements
   - Type Annotate inject, reformat, and move import to top.
     inject() passes each statement to PyRun_SimpleString(), which should now
     work with code blocks and are more readable. And add mailto=False option for local debug

The bugfix itself that claude opus helped to understand:


Avoid core dump when remote debugging is interrupted (#131)

Sending a signal to a process while it is being remotely debugged aborts
it:

    Fatal Python error: PyGILState_Release: thread state 0x... must be
    current when releasing

    Current thread 0x... (most recent call first):
      File ".../pyflyby/_dbg.py", line 636 in _sleep_until_debugger_attaches
      File ".../pyflyby/_dbg.py", line 679 in wait_for_debugger_to_attach
      File ".../pyflyby/_dbg.py", line 528 in debugger
      ...

inject() ran the GIL handshake as three separate gdb commands:

    call PyGILState_Ensure()
    call PyRun_SimpleString("...")
    call PyGILState_Release($1)

I'm not completely sure of why and how this is happening, but my
understanding is that the thread state between ensure and Release get
changed if we run the interrupt or exception handler, and thus we try to
release from the wrong thread state.

I'm not familiar wnough with CPython internal to get all that, but my
understanding is that we can just not release the gil and leak it to
avoid the crash.

This debugging and reasoning was helped with Claude Opus, which
apparently understand it, as much as a large language model can do that.
It also told me about the gdb comma separator which I was nto aware of.

I believe is is fine and better to leak the Gil than to crash.
I'm sure it can have side effect, but AFAICT this does not prevent
future reattach, and maybe it could block later things that try to
capture the gil, but it is still better as mostly this is used for
debugging.

So we'll take the tradeoff.

This in itself does not completely fix the issue 131 which is dues to a
change in import machinery.

Refs #131.

--- 


